### PR TITLE
Colorize with domain models ordered by dependency

### DIFF
--- a/ORM2CommandLineTest/ORMDocServices.cs
+++ b/ORM2CommandLineTest/ORMDocServices.cs
@@ -51,6 +51,11 @@ namespace ORMSolutions.ORMArchitectSDK.TestEngine
 				// This is implemented on a per-store basis, we don't implement it on the document services
 				return null;
 			}
+			T[] IFrameworkServices.GetTypedDomainModelProviders<T>(bool dependencyOrder)
+			{
+				// This is implemented on a per-store basis, we don't implement it on the document services
+				return null;
+			}
 			ICopyClosureManager IFrameworkServices.CopyClosureManager
 			{
 				get

--- a/ORM2CommandLineTest/ORMStore.cs
+++ b/ORM2CommandLineTest/ORMStore.cs
@@ -125,7 +125,17 @@ namespace ORMSolutions.ORMArchitectSDK.TestEngine
 				{
 					myTypedDomainModelCache = cache = new TypedDomainModelProviderCache(this);
 				}
-				return cache.GetTypedDomainModelProviders<T>();
+				return cache.GetTypedDomainModelProviders<T>(false);
+			}
+			T[] IFrameworkServices.GetTypedDomainModelProviders<T>(bool dependencyOrder)
+			{
+				// Implemented on a per-store basis, do not defer to myServices
+				TypedDomainModelProviderCache cache = myTypedDomainModelCache;
+				if (cache == null)
+				{
+					myTypedDomainModelCache = cache = new TypedDomainModelProviderCache(this);
+				}
+				return cache.GetTypedDomainModelProviders<T>(dependencyOrder);
 			}
 			private CopyClosureManager myCopyClosureManager;
 			ICopyClosureManager IFrameworkServices.CopyClosureManager

--- a/ORMModel/Framework/FrameworkServices.cs
+++ b/ORMModel/Framework/FrameworkServices.cs
@@ -78,10 +78,17 @@ namespace ORMSolutions.ORMArchitect.Framework
 		/// Can be implemented using the <see cref="TypedDomainModelProviderCache"/> class.
 		/// </summary>
 		/// <typeparam name="T">The interface to test</typeparam>
+		/// <returns>An array of instances, or null</returns>
+		T[] GetTypedDomainModelProviders<T>() where T : class;
+		/// <summary>
+		/// Retrieve a cached set of domain model instances that implement the requested interface.
+		/// Can be implemented using the <see cref="TypedDomainModelProviderCache"/> class.
+		/// </summary>
+		/// <typeparam name="T">The interface to test</typeparam>
 		/// <param name="dependencyOrder">If true, then return multiple matches in
 		/// dependency order, with the least dependent models first.</param>
 		/// <returns>An array of instances, or null</returns>
-		T[] GetTypedDomainModelProviders<T>(bool dependencyOrder = false) where T : class;
+		T[] GetTypedDomainModelProviders<T>(bool dependencyOrder) where T : class;
 		/// <summary>
 		/// Retrieve the <see cref="ICopyClosureManager"/> interface for this store.
 		/// Can be implemented using an instance of the <see cref="CopyClosureManager"/>

--- a/ORMModel/Framework/FrameworkServices.cs
+++ b/ORMModel/Framework/FrameworkServices.cs
@@ -78,8 +78,10 @@ namespace ORMSolutions.ORMArchitect.Framework
 		/// Can be implemented using the <see cref="TypedDomainModelProviderCache"/> class.
 		/// </summary>
 		/// <typeparam name="T">The interface to test</typeparam>
+		/// <param name="dependencyOrder">If true, then return multiple matches in
+		/// dependency order, with the least dependent models first.</param>
 		/// <returns>An array of instances, or null</returns>
-		T[] GetTypedDomainModelProviders<T>() where T : class;
+		T[] GetTypedDomainModelProviders<T>(bool dependencyOrder = false) where T : class;
 		/// <summary>
 		/// Retrieve the <see cref="ICopyClosureManager"/> interface for this store.
 		/// Can be implemented using an instance of the <see cref="CopyClosureManager"/>
@@ -133,6 +135,67 @@ namespace ORMSolutions.ORMArchitect.Framework
 		object ReferencedElement { get;}
 	}
 	#endregion // IElementReference interface
+	#region SoftExtensionDependencyAttribute class
+	/// <summary>
+	/// An attribute to add to a domain model to create a dependency on a domain
+	/// model that might not be loaded. This will force the attributed domain model
+	/// to load after the targeted domain model if the targeted model is loaded
+	/// for some other reason. This allows relative load order to be specified
+	/// between extension models that do not have hard dependencies on each other.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+	public class SoftExtensionDependencyAttribute : Attribute
+	{
+		private Guid myDependentExtensionId;
+		/// <summary>
+		/// Create a default <see cref="SoftExtensionDependencyAttribute"/>
+		/// </summary>
+		public SoftExtensionDependencyAttribute()
+		{
+			myDependentExtensionId = Guid.Empty;
+		}
+		/// <summary>
+		/// Create a <see cref="SoftExtensionDependencyAttribute"/> for a specific domain model.
+		/// </summary>
+		/// <param name="domainModelId">The model if for soft dependency.</param>
+		public SoftExtensionDependencyAttribute(string domainModelId)
+		{
+			myDependentExtensionId = new Guid(domainModelId);
+		}
+		/// <summary>
+		/// The <see cref="Guid"/> form of the identifier.
+		/// </summary>
+		public Guid DependentExtensionId
+		{
+			get
+			{
+				return myDependentExtensionId;
+			}
+		}
+		/// <summary>
+		/// The string form of the model identifier. Used during
+		/// attribute construction.
+		/// </summary>
+		public string DependentExtensionIdString
+		{
+			get
+			{
+				return myDependentExtensionId.ToString();
+			}
+			set
+			{
+				myDependentExtensionId = new Guid(value);
+			}
+		}
+		/// <summary>
+		/// Standard override, empty if id not set
+		/// </summary>
+		public override bool IsDefaultAttribute()
+		{
+			return myDependentExtensionId == Guid.Empty;
+		}
+	}
+	#endregion // SoftExtensionDependencyAttribute class
 	#region DomainModelTypeProviderCache class
 	/// <summary>
 	/// Helper class to implement <see cref="M:IFrameworkServices.GetTypedDomainModelProviders"/>
@@ -141,6 +204,8 @@ namespace ORMSolutions.ORMArchitect.Framework
 	{
 		private Store myStore;
 		private Dictionary<Type, Array> myProviderCache;
+		private Dictionary<Type, Array> myDependecyOrderedProviderCache;
+		private DomainModel[] myDependencyOrderedDomainModels;
 		/// <summary>
 		/// Create a new DomainModelTypeProviderCache
 		/// </summary>
@@ -162,15 +227,28 @@ namespace ORMSolutions.ORMArchitect.Framework
 		/// <summary>
 		/// Get an array of providers of the requested type, or null if the interface is not implemented
 		/// </summary>
-		public T[] GetTypedDomainModelProviders<T>() where T : class
+		/// <param name="dependencyOrder">Return matching domain models in strict
+		/// dependency order, with less dependent domain models listed first.</param>
+		public T[] GetTypedDomainModelProviders<T>(bool dependencyOrder) where T : class
 		{
 			T[] retVal;
-			Dictionary<Type, Array> cache = myProviderCache;
+			Dictionary<Type, Array> cache = dependencyOrder ? myDependecyOrderedProviderCache : myProviderCache;
 			Type TType = typeof(T);
 			if (cache == null)
 			{
-				myProviderCache = cache = new Dictionary<Type, Array>();
-				retVal = Utility.GetTypedDomainModels<T>(myStore.DomainModels);
+				cache = new Dictionary<Type, Array>();
+				IEnumerable<DomainModel> models;
+				if (dependencyOrder)
+				{
+					myDependecyOrderedProviderCache = cache;
+					models = myDependencyOrderedDomainModels = GetDependencyOrderedDomainModels(myStore);
+				}
+				else
+				{
+					myProviderCache = cache;
+					models = myStore.DomainModels;
+				}
+				retVal = Utility.GetTypedDomainModels<T>(models);
 				cache.Add(TType, retVal);
 			}
 			else
@@ -182,11 +260,154 @@ namespace ORMSolutions.ORMArchitect.Framework
 				}
 				else
 				{
-					retVal = Utility.GetTypedDomainModels<T>(myStore.DomainModels);
+					retVal = Utility.GetTypedDomainModels<T>(dependencyOrder ? (IEnumerable<DomainModel>)myDependencyOrderedDomainModels : myStore.DomainModels);
 					cache.Add(TType, retVal);
 				}
 			}
 			return retVal;
+		}
+		private static DomainModel[] GetDependencyOrderedDomainModels(Store store)
+		{
+			// Get basic information
+			ICollection<DomainModel> startModels = store.DomainModels;
+			int modelCount = startModels.Count;
+			DomainModel[] allModels = new DomainModel[modelCount];
+			startModels.CopyTo(allModels, 0);
+
+			// There is no way to do a dependency graph sort using a quicksort, so we do a
+			// topological sort instead (this is a directed acyclic graph)
+
+			// Track head nodes (that nothing depends on). We default these to the original
+			// model index, then change to ~index as we examine the contents to indicate a
+			// non-head node. This also gives us a quick lookup to see if a referenced target
+			// is actually included in our original list.
+			Dictionary<Guid, int> headNodes = new Dictionary<Guid, int>();
+			for (int i = 0; i < modelCount; ++i)
+			{
+				headNodes[allModels[i].DomainModelInfo.Id] = i;
+			}
+
+			// A dictionary of direct dependencies. We filter the dependencies before adding to
+			// guarantee that the target is available.
+			Dictionary<Guid, Guid[]> directDependencies = new Dictionary<Guid, Guid[]>();
+
+			// Retrieve direct dependency information for both hard and soft dependencies
+			List<Guid> dependentIds = new List<Guid>();
+			for (int iModel = 0; iModel < modelCount; ++iModel)
+			{
+				dependentIds.Clear();
+				int dependentCount = 0;
+				DomainModel domainModel = allModels[iModel];
+				Type type = domainModel.GetType();
+#if VISUALSTUDIO_10_0
+				object[] extendsAttributes = type.GetCustomAttributes(typeof(DependsOnDomainModelAttribute), false);
+#else
+				object[] extendsAttributes = type.GetCustomAttributes(typeof(ExtendsDomainModelAttribute), false);
+#endif
+				for (int i = 0; i < extendsAttributes.Length; ++i)
+				{
+#if VISUALSTUDIO_10_0
+					Type extendedModelType = ((DependsOnDomainModelAttribute)extendsAttributes[i]).ExtendedDomainModelType;
+					object[] extensionIdAttributes = extendedModelType.GetCustomAttributes(typeof(DomainObjectIdAttribute), false);
+					Guid dependentId = (extensionIdAttributes.Length != 0) ? ((DomainObjectIdAttribute)extensionIdAttributes[0]).Id : Guid.Empty;
+#else
+					Guid dependentId = ((ExtendsDomainModelAttribute)extendsAttributes[i]).ExtendedModelId;
+#endif
+					int headIndex;
+					if (dependentId != Guid.Empty && headNodes.TryGetValue(dependentId, out headIndex))
+					{
+						if (headIndex >= 0)
+						{
+							headNodes[dependentId] = ~headIndex;
+						}
+						dependentIds.Add(dependentId);
+						++dependentCount;
+					}
+				}
+
+				// Do the same for soft extensions, which apply only if the target model is loaded
+				// but have no effect otherwise.
+				extendsAttributes = type.GetCustomAttributes(typeof(SoftExtensionDependencyAttribute), false);
+				for (int i = 0; i < extendsAttributes.Length; ++i)
+				{
+					Guid dependentId = ((SoftExtensionDependencyAttribute)extendsAttributes[i]).DependentExtensionId;
+					int headIndex;
+					if (dependentId != Guid.Empty && headNodes.TryGetValue(dependentId, out headIndex))
+					{
+						if (headIndex >= 0)
+						{
+							headNodes[dependentId] = ~headIndex;
+						}
+						dependentIds.Add(dependentId);
+						++dependentCount;
+					}
+				}
+
+				if (dependentCount != 0)
+				{
+					if (dependentCount > 1)
+					{
+						// Sort based on original order so we preserve as much
+						// of the default (class name based) order as we can.
+						dependentIds.Sort(delegate (Guid x, Guid y)
+						{
+							int index1 = headNodes[x];
+							if (index1 < 0)
+							{
+								index1 = ~index1;
+							}
+							int index2 = headNodes[y];
+							if (index2 < 0)
+							{
+								index2 = ~index1;
+							}
+							return index1.CompareTo(index2);
+						});
+					}
+					Guid[] dependentResult = new Guid[dependentCount];
+					dependentIds.CopyTo(dependentResult, 0);
+					directDependencies[domainModel.DomainModelInfo.Id] = dependentResult;
+				}
+			}
+
+			// Apply a recursive depth-first-sort algorithm starting from head nodes, record the results.
+			DomainModel[] retVal = new DomainModel[modelCount];
+			int nextResultIndex = 0;
+			foreach (KeyValuePair<Guid, int> kvp in headNodes)
+			{
+				if (kvp.Value >= 0) // Index not inverted, nothing references this
+				{
+					VisitDependencies(kvp.Key, headNodes, directDependencies, allModels, retVal, ref nextResultIndex);
+				}
+			}
+
+			return retVal;
+		}
+		private static void VisitDependencies(Guid modelId, Dictionary<Guid, int> headNodes, Dictionary<Guid, Guid[]> directDependencies, DomainModel[] allModels, DomainModel[] results, ref int nextResultIndex)
+		{
+			int modelIndex = headNodes[modelId];
+			if (modelIndex < 0)
+			{
+				modelIndex = ~modelIndex;
+			}
+			DomainModel model = allModels[modelIndex];
+			if (model == null)
+			{
+				// Already processed
+				return;
+			}
+			allModels[modelIndex] = null;
+
+			Guid[] dependencies;
+			if (directDependencies.TryGetValue(modelId, out dependencies))
+			{
+				for (int i = 0; i < dependencies.Length; ++i)
+				{
+					VisitDependencies(dependencies[i], headNodes, directDependencies, allModels, results, ref nextResultIndex);
+				}
+			}
+			results[nextResultIndex] = model;
+			++nextResultIndex;
 		}
 	}
 	#endregion // DomainModelTypeProviderCache class

--- a/ORMModel/Load/ExtensionLoader.cs
+++ b/ORMModel/Load/ExtensionLoader.cs
@@ -320,7 +320,7 @@ namespace ORMSolutions.ORMArchitect.Core.Load
 			}
 		}
 		/// <summary>
-		/// The identifiers for the <see cref="DomainClassInfo"/> models
+		/// The identifiers for the <see cref="DomainModelInfo"/> models
 		/// extended by this extension.
 		/// </summary>
 		public ICollection<Guid> ExtendsDomainModelIds

--- a/ORMModel/Load/ModelLoader.cs
+++ b/ORMModel/Load/ModelLoader.cs
@@ -286,18 +286,18 @@ namespace ORMSolutions.ORMArchitect.Core.Load
 		/// <summary>
 		/// Implements <see cref="IFrameworkServices.GetTypedDomainModelProviders"/>.
 		/// </summary>
-		protected T[] GetTypedDomainModelProviders<T>() where T : class
+		protected T[] GetTypedDomainModelProviders<T>(bool dependencyOrder) where T : class
 		{
 			TypedDomainModelProviderCache cache = myTypedDomainModelCache;
 			if (cache == null)
 			{
 				myTypedDomainModelCache = cache = new TypedDomainModelProviderCache(this);
 			}
-			return cache.GetTypedDomainModelProviders<T>();
+			return cache.GetTypedDomainModelProviders<T>(dependencyOrder);
 		}
-		T[] IFrameworkServices.GetTypedDomainModelProviders<T>()
+		T[] IFrameworkServices.GetTypedDomainModelProviders<T>(bool dependencyOrder)
 		{
-			return GetTypedDomainModelProviders<T>();
+			return GetTypedDomainModelProviders<T>(dependencyOrder);
 		}
 		private CopyClosureManager myCopyClosureManager;
 		/// <summary>

--- a/ORMModel/Load/ModelLoader.cs
+++ b/ORMModel/Load/ModelLoader.cs
@@ -284,7 +284,7 @@ namespace ORMSolutions.ORMArchitect.Core.Load
 		}
 		private TypedDomainModelProviderCache myTypedDomainModelCache;
 		/// <summary>
-		/// Implements <see cref="IFrameworkServices.GetTypedDomainModelProviders"/>.
+		/// Implements <see cref="IFrameworkServices.GetTypedDomainModelProviders(System.Boolean)"/>.
 		/// </summary>
 		protected T[] GetTypedDomainModelProviders<T>(bool dependencyOrder) where T : class
 		{
@@ -294,6 +294,10 @@ namespace ORMSolutions.ORMArchitect.Core.Load
 				myTypedDomainModelCache = cache = new TypedDomainModelProviderCache(this);
 			}
 			return cache.GetTypedDomainModelProviders<T>(dependencyOrder);
+		}
+		T[] IFrameworkServices.GetTypedDomainModelProviders<T>()
+		{
+			return GetTypedDomainModelProviders<T>(false);
 		}
 		T[] IFrameworkServices.GetTypedDomainModelProviders<T>(bool dependencyOrder)
 		{

--- a/ORMModel/ShapeModel/CardinalityConstraintShape.cs
+++ b/ORMModel/ShapeModel/CardinalityConstraintShape.cs
@@ -99,7 +99,7 @@ namespace ORMSolutions.ORMArchitect.Core.ShapeModel
 			if (((isAlethic = (brushId == CardinalityTextAlethicBrush)) || brushId == CardinalityTextDeonticBrush) &&
 				null != (solidBrush = brush as SolidBrush) &&
 				null != (store = Utility.ValidateStore(Store)) &&
-				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, CardinalityConstraintShape, CardinalityConstraint>>()) &&
+				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, CardinalityConstraintShape, CardinalityConstraint>>(true)) &&
 				null != (element = (CardinalityConstraint)ModelElement))
 			{
 				for (int i = 0; i < providers.Length; ++i)

--- a/ORMModel/ShapeModel/ExternalConstraintLink.cs
+++ b/ORMModel/ShapeModel/ExternalConstraintLink.cs
@@ -342,7 +342,7 @@ namespace ORMSolutions.ORMArchitect.Core.ShapeModel
 				penId == DiagramPens.ConnectionLineDecorator) &&
 				null != (store = Utility.ValidateStore(Store)) &&
 				null != (constraint = AssociatedConstraint) &&
-				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, ExternalConstraintLink, IConstraint>>()))
+				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, ExternalConstraintLink, IConstraint>>(true)))
 			{
 				ORMDiagramDynamicColor requestColor = constraint.Modality == ConstraintModality.Deontic ? ORMDiagramDynamicColor.DeonticConstraint : ORMDiagramDynamicColor.Constraint;
 				for (int i = 0; i < providers.Length; ++i)
@@ -376,7 +376,7 @@ namespace ORMSolutions.ORMArchitect.Core.ShapeModel
 				null != (store = Utility.ValidateStore(Store)) &&
 				null != (constraint = AssociatedConstraint) &&
 				null != (solidBrush = brush as SolidBrush) &&
-				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, ExternalConstraintLink, IConstraint>>()))
+				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, ExternalConstraintLink, IConstraint>>(true)))
 			{
 				ORMDiagramDynamicColor requestColor = constraint.Modality == ConstraintModality.Deontic ? ORMDiagramDynamicColor.DeonticConstraint : ORMDiagramDynamicColor.Constraint;
 				for (int i = 0; i < providers.Length; ++i)

--- a/ORMModel/ShapeModel/ExternalConstraintShape.cs
+++ b/ORMModel/ShapeModel/ExternalConstraintShape.cs
@@ -450,7 +450,7 @@ namespace ORMSolutions.ORMArchitect.Core.ShapeModel
 			Store store;
 			if (penId == DiagramPens.ShapeOutline &&
 				null != (store = Utility.ValidateStore(Store)) &&
-				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, ExternalConstraintShape, IConstraint>>()) &&
+				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, ExternalConstraintShape, IConstraint>>(true)) &&
 				null != (element = (IConstraint)ModelElement))
 			{
 				ORMDiagramDynamicColor requestColor = element.Modality == ConstraintModality.Deontic ? ORMDiagramDynamicColor.DeonticConstraint : ORMDiagramDynamicColor.Constraint;
@@ -492,7 +492,7 @@ namespace ORMSolutions.ORMArchitect.Core.ShapeModel
 				brushId == DiagramBrushes.ShapeText) &&
 				null != (solidBrush = brush as SolidBrush) &&
 				null != (store = Utility.ValidateStore(Store)) &&
-				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, ExternalConstraintShape, IConstraint>>()) &&
+				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, ExternalConstraintShape, IConstraint>>(true)) &&
 				null != (element = (IConstraint)ModelElement))
 			{
 				ORMDiagramDynamicColor requestColor = element.Modality == ConstraintModality.Deontic ? ORMDiagramDynamicColor.DeonticConstraint : ORMDiagramDynamicColor.Constraint;

--- a/ORMModel/ShapeModel/FactTypeShape.cs
+++ b/ORMModel/ShapeModel/FactTypeShape.cs
@@ -1870,7 +1870,7 @@ namespace ORMSolutions.ORMArchitect.Core.ShapeModel
 				StyleSet styleSet = factShape.StyleSet;
 				Pen alethicConstraintPen = styleSet.GetPen(InternalFactConstraintPen);
 				Pen deonticConstraintPen = styleSet.GetPen(DeonticInternalFactConstraintPen);
-				IDynamicShapeColorProvider<ORMDiagramDynamicColor, FactTypeShape, IConstraint>[] dynamicColorProviders = ((IFrameworkServices)parentShape.Store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, FactTypeShape, IConstraint>>();
+				IDynamicShapeColorProvider<ORMDiagramDynamicColor, FactTypeShape, IConstraint>[] dynamicColorProviders = ((IFrameworkServices)parentShape.Store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, FactTypeShape, IConstraint>>(true);
 				float gap = alethicConstraintPen.Width;
 				ConstraintAttachPosition attachPosition = AttachPosition;
 				ConstraintDisplayPosition position = factShape.DisplayPositionFromAttachPosition(attachPosition);
@@ -5474,7 +5474,7 @@ namespace ORMSolutions.ORMArchitect.Core.ShapeModel
 			if (((isRoleBox = (penId == RoleBoxResource || penId == LinkFactTypeRoleBoxResource)) ||
 				penId == DiagramPens.ShapeOutline) &&
 				null != (store = Utility.ValidateStore(Store)) &&
-				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, FactTypeShape, FactType>>()) &&
+				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, FactTypeShape, FactType>>(true)) &&
 				null != (element = (FactType)ModelElement))
 			{
 				ORMDiagramDynamicColor requestColor = isRoleBox ? ORMDiagramDynamicColor.ForegroundGraphics : ORMDiagramDynamicColor.Outline;
@@ -5510,7 +5510,7 @@ namespace ORMSolutions.ORMArchitect.Core.ShapeModel
 				(textBrush = (brushId == DiagramBrushes.ShapeTitleText && DisplayAsObjectType))) &&
 				null != (solidBrush = brush as SolidBrush) &&
 				null != (store = Utility.ValidateStore(Store)) &&
-				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, FactTypeShape, FactType>>()) &&
+				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, FactTypeShape, FactType>>(true)) &&
 				null != (element = (FactType)ModelElement))
 			{
 				for (int i = 0; i < providers.Length; ++i)
@@ -7455,7 +7455,7 @@ namespace ORMSolutions.ORMArchitect.Core.ShapeModel
 			if (brushId == DiagramBrushes.ShapeText &&
 				null != (solidBrush = brush as SolidBrush) &&
 				null != (store = Utility.ValidateStore(Store)) &&
-				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, ObjectifiedFactTypeNameShape, ObjectType>>()) &&
+				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, ObjectifiedFactTypeNameShape, ObjectType>>(true)) &&
 				null != (objectType = this.AssociatedObjectType))
 			{
 				for (int i = 0; i < providers.Length; ++i)

--- a/ORMModel/ShapeModel/ModelNoteShape.cs
+++ b/ORMModel/ShapeModel/ModelNoteShape.cs
@@ -150,7 +150,7 @@ namespace ORMSolutions.ORMArchitect.Core.ShapeModel
 			IDynamicShapeColorProvider<ORMDiagramDynamicColor, ModelNoteShape, ModelNote>[] providers;
 			if (penId == DiagramPens.ShapeOutline &&
 				null != (store = Utility.ValidateStore(Store)) &&
-				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, ModelNoteShape, ModelNote>>()) &&
+				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, ModelNoteShape, ModelNote>>(true)) &&
 				null != (element = (ModelNote)ModelElement))
 			{
 				for (int i = 0; i < providers.Length; ++i)
@@ -185,7 +185,7 @@ namespace ORMSolutions.ORMArchitect.Core.ShapeModel
 				brushId == DiagramBrushes.ShapeText) &&
 				null != (solidBrush = brush as SolidBrush) &&
 				null != (store = Utility.ValidateStore(Store)) &&
-				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, ModelNoteShape, ModelNote>>()) &&
+				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, ModelNoteShape, ModelNote>>(true)) &&
 				null != (element = (ModelNote)ModelElement))
 			{
 				ORMDiagramDynamicColor requestColor = ORMDiagramDynamicColor.Background;

--- a/ORMModel/ShapeModel/ObjectTypeShape.cs
+++ b/ORMModel/ShapeModel/ObjectTypeShape.cs
@@ -131,7 +131,7 @@ namespace ORMSolutions.ORMArchitect.Core.ShapeModel
 			Store store;
 			if ((penId == DashedShapeOutlinePen || penId == DiagramPens.ShapeOutline) &&
 				null != (store = Utility.ValidateStore(Store)) &&
-				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, ObjectTypeShape, ObjectType>>()) &&
+				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, ObjectTypeShape, ObjectType>>(true)) &&
 				null != (element = (ObjectType)ModelElement))
 			{
 				for (int i = 0; i < providers.Length; ++i)
@@ -166,7 +166,7 @@ namespace ORMSolutions.ORMArchitect.Core.ShapeModel
 				brushId == DiagramBrushes.ShapeTitleText) &&
 				null != (solidBrush = brush as SolidBrush) &&
 				null != (store = Utility.ValidateStore(Store)) &&
-				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, ObjectTypeShape, ObjectType>>()) &&
+				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, ObjectTypeShape, ObjectType>>(true)) &&
 				null != (element = (ObjectType)ModelElement))
 			{
 				ORMDiagramDynamicColor requestColor = isBackgroundBrush ? ORMDiagramDynamicColor.Background : ORMDiagramDynamicColor.ForegroundText;

--- a/ORMModel/ShapeModel/ReadingShape.cs
+++ b/ORMModel/ShapeModel/ReadingShape.cs
@@ -65,7 +65,7 @@ namespace ORMSolutions.ORMArchitect.Core.ShapeModel
 			if (brushId == DiagramBrushes.ShapeText &&
 				null != (solidBrush = brush as SolidBrush) &&
 				null != (store = Utility.ValidateStore(Store)) &&
-				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, FactTypeShape, FactType>>()) &&
+				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, FactTypeShape, FactType>>(true)) &&
 				null != (factTypeShape = ParentShape as FactTypeShape) &&
 				null != (factType = factTypeShape.AssociatedFactType))
 			{

--- a/ORMModel/ShapeModel/RoleNameShape.cs
+++ b/ORMModel/ShapeModel/RoleNameShape.cs
@@ -181,7 +181,7 @@ namespace ORMSolutions.ORMArchitect.Core.ShapeModel
 			if (brushId == RoleNameTextBrush &&
 				null != (solidBrush = brush as SolidBrush) &&
 				null != (store = Utility.ValidateStore(Store)) &&
-				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, RoleNameShape, RoleBase>>()) &&
+				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, RoleNameShape, RoleBase>>(true)) &&
 				null != (element = (RoleBase)ModelElement))
 			{
 				for (int i = 0; i < providers.Length; ++i)

--- a/ORMModel/ShapeModel/RolePlayerLink.cs
+++ b/ORMModel/ShapeModel/RolePlayerLink.cs
@@ -269,7 +269,7 @@ namespace ORMSolutions.ORMArchitect.Core.ShapeModel
 				if (forLink)
 				{
 					IDynamicShapeColorProvider<ORMDiagramDynamicColor, RolePlayerLink, ObjectTypePlaysRole>[] providers;
-					if (null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, RolePlayerLink, ObjectTypePlaysRole>>()))
+					if (null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, RolePlayerLink, ObjectTypePlaysRole>>(true)))
 					{
 						for (int i = 0; i < providers.Length; ++i)
 						{
@@ -288,7 +288,7 @@ namespace ORMSolutions.ORMArchitect.Core.ShapeModel
 					IDynamicShapeColorProvider<ORMDiagramDynamicColor, RolePlayerLink, MandatoryConstraint>[] providers;
 					Role playedRole;
 					MandatoryConstraint mandatory;
-					if (null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, RolePlayerLink, MandatoryConstraint>>()) &&
+					if (null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, RolePlayerLink, MandatoryConstraint>>(true)) &&
 						null != (playedRole = link.PlayedRole) &&
 						null != (mandatory = playedRole.SimpleMandatoryConstraint))
 					{
@@ -326,7 +326,7 @@ namespace ORMSolutions.ORMArchitect.Core.ShapeModel
 			Store store;
 			if (brushId == DiagramBrushes.ConnectionLineDecorator &&
 				null != (store = Utility.ValidateStore(Store)) &&
-				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, RolePlayerLink, MandatoryConstraint>>()) &&
+				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, RolePlayerLink, MandatoryConstraint>>(true)) &&
 				null != (solidBrush = brush as SolidBrush) &&
 				null != (link = ModelElement as ObjectTypePlaysRole) &&
 				null != (playedRole = link.PlayedRole) &&

--- a/ORMModel/ShapeModel/SubtypeLink.cs
+++ b/ORMModel/ShapeModel/SubtypeLink.cs
@@ -340,7 +340,7 @@ namespace ORMSolutions.ORMArchitect.Core.ShapeModel
 				penId == NonPrimaryNormalResource ||
 				penId == DiagramPens.ConnectionLineDecorator) &&
 				null != (store = Utility.ValidateStore(Store)) &&
-				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, SubtypeLink, SubtypeFact>>()) &&
+				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, SubtypeLink, SubtypeFact>>(true)) &&
 				null != (element = (SubtypeFact)ModelElement))
 			{
 				for (int i = 0; i < providers.Length; ++i)
@@ -373,7 +373,7 @@ namespace ORMSolutions.ORMArchitect.Core.ShapeModel
 			if (brushId == DiagramBrushes.ConnectionLineDecorator &&
 				null != (solidBrush = brush as SolidBrush) &&
 				null != (store = Utility.ValidateStore(Store)) &&
-				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, SubtypeLink, SubtypeFact>>()) &&
+				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, SubtypeLink, SubtypeFact>>(true)) &&
 				null != (element = (SubtypeFact)ModelElement))
 			{
 				for (int i = 0; i < providers.Length; ++i)

--- a/ORMModel/ShapeModel/ValueRangeLink.cs
+++ b/ORMModel/ShapeModel/ValueRangeLink.cs
@@ -87,7 +87,7 @@ namespace ORMSolutions.ORMArchitect.Core.ShapeModel
 				null != (link = ModelElement as RoleHasValueConstraint) &&
 				null != (constraint = link.ValueConstraint) &&
 				null != (store = Utility.ValidateStore(Store)) &&
-				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, ValueRangeLink, RoleValueConstraint>>()))
+				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, ValueRangeLink, RoleValueConstraint>>(true)))
 			{
 				for (int i = 0; i < providers.Length; ++i)
 				{

--- a/ORMModel/ShapeModel/ValueRangeShape.cs
+++ b/ORMModel/ShapeModel/ValueRangeShape.cs
@@ -91,7 +91,7 @@ namespace ORMSolutions.ORMArchitect.Core.ShapeModel
 			if (brushId == ValueRangeTextBrush &&
 				null != (solidBrush = brush as SolidBrush) &&
 				null != (store = Utility.ValidateStore(Store)) &&
-				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, ValueConstraintShape, ValueConstraint>>()) &&
+				null != (providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMDiagramDynamicColor, ValueConstraintShape, ValueConstraint>>(true)) &&
 				null != (element = (ValueConstraint)ModelElement))
 			{
 				for (int i = 0; i < providers.Length; ++i)

--- a/ORMModel/Shell/ORMDocDataServices.cs
+++ b/ORMModel/Shell/ORMDocDataServices.cs
@@ -273,11 +273,15 @@ namespace ORMSolutions.ORMArchitect.Core.Shell
 				}
 			}
 			/// <summary>
-			/// Defer to <see cref="IFrameworkServices.GetTypedDomainModelProviders"/> on the document.
+			/// Defer to <see cref="IFrameworkServices.GetTypedDomainModelProviders(System.Boolean)"/> on the document.
 			/// </summary>
 			protected T[] GetTypedDomainModelProviders<T>(bool dependencyOrder) where T : class
 			{
 				return myServices.GetTypedDomainModelProviders<T>(dependencyOrder);
+			}
+			T[] IFrameworkServices.GetTypedDomainModelProviders<T>()
+			{
+				return GetTypedDomainModelProviders<T>(false);
 			}
 			T[] IFrameworkServices.GetTypedDomainModelProviders<T>(bool dependencyOrder)
 			{
@@ -1498,7 +1502,7 @@ namespace ORMSolutions.ORMArchitect.Core.Shell
 		}
 		/// <summary>
 		/// Retrieve the domain models that implement a given interface for this model
-		/// Implements <see cref="IFrameworkServices.GetTypedDomainModelProviders"/>.
+		/// Implements <see cref="IFrameworkServices.GetTypedDomainModelProviders(System.Boolean)"/>.
 		/// </summary>
 		protected T[] GetTypedDomainModelProviders<T>(bool dependencyOrder) where T : class
 		{
@@ -1516,6 +1520,10 @@ namespace ORMSolutions.ORMArchitect.Core.Shell
 				myTypedDomainModelProviderCache = cache = new TypedDomainModelProviderCache(store);
 			}
 			return cache.GetTypedDomainModelProviders<T>(dependencyOrder);
+		}
+		T[] IFrameworkServices.GetTypedDomainModelProviders<T>()
+		{
+			return GetTypedDomainModelProviders<T>(false);
 		}
 		T[] IFrameworkServices.GetTypedDomainModelProviders<T>(bool dependencyOrder)
 		{

--- a/ORMModel/Shell/ORMDocDataServices.cs
+++ b/ORMModel/Shell/ORMDocDataServices.cs
@@ -194,7 +194,7 @@ namespace ORMSolutions.ORMArchitect.Core.Shell
 					if (!myCheckedColors)
 					{
 						myCheckedColors = true;
-						myColorsEnabled = null != ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMModelBrowserDynamicColor, ShapeElement, ModelElement>>();
+						myColorsEnabled = null != ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMModelBrowserDynamicColor, ShapeElement, ModelElement>>(true);
 					}
 					return myColorsEnabled;
 				}
@@ -207,7 +207,7 @@ namespace ORMSolutions.ORMArchitect.Core.Shell
 					null != (store = Utility.ValidateStore(this.SurveyContext)))
 				{
 					// We know the next one will succeed because it worked for DynamicColorsEnabled
-					IDynamicShapeColorProvider<ORMModelBrowserDynamicColor, ShapeElement, ModelElement>[] providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMModelBrowserDynamicColor, ShapeElement, ModelElement>>();
+					IDynamicShapeColorProvider<ORMModelBrowserDynamicColor, ShapeElement, ModelElement>[] providers = ((IFrameworkServices)store).GetTypedDomainModelProviders<IDynamicShapeColorProvider<ORMModelBrowserDynamicColor, ShapeElement, ModelElement>>(true);
 					ORMModelBrowserDynamicColor checkColor = (colorRole == SurveyDynamicColor.ForeColor) ? ORMModelBrowserDynamicColor.Foreground : ORMModelBrowserDynamicColor.Background;
 					for (int i = 0; i < providers.Length; ++i)
 					{
@@ -275,13 +275,13 @@ namespace ORMSolutions.ORMArchitect.Core.Shell
 			/// <summary>
 			/// Defer to <see cref="IFrameworkServices.GetTypedDomainModelProviders"/> on the document.
 			/// </summary>
-			protected T[] GetTypedDomainModelProviders<T>() where T : class
+			protected T[] GetTypedDomainModelProviders<T>(bool dependencyOrder) where T : class
 			{
-				return myServices.GetTypedDomainModelProviders<T>();
+				return myServices.GetTypedDomainModelProviders<T>(dependencyOrder);
 			}
-			T[] IFrameworkServices.GetTypedDomainModelProviders<T>()
+			T[] IFrameworkServices.GetTypedDomainModelProviders<T>(bool dependencyOrder)
 			{
-				return GetTypedDomainModelProviders<T>();
+				return GetTypedDomainModelProviders<T>(dependencyOrder);
 			}
 			/// <summary>
 			/// Defer to <see cref="IFrameworkServices.CopyClosureManager"/> on the document.
@@ -1500,7 +1500,7 @@ namespace ORMSolutions.ORMArchitect.Core.Shell
 		/// Retrieve the domain models that implement a given interface for this model
 		/// Implements <see cref="IFrameworkServices.GetTypedDomainModelProviders"/>.
 		/// </summary>
-		protected T[] GetTypedDomainModelProviders<T>() where T : class
+		protected T[] GetTypedDomainModelProviders<T>(bool dependencyOrder) where T : class
 		{
 			// Defensively verify store state
 			TypedDomainModelProviderCache cache = myTypedDomainModelProviderCache;
@@ -1515,11 +1515,11 @@ namespace ORMSolutions.ORMArchitect.Core.Shell
 				}
 				myTypedDomainModelProviderCache = cache = new TypedDomainModelProviderCache(store);
 			}
-			return cache.GetTypedDomainModelProviders<T>();
+			return cache.GetTypedDomainModelProviders<T>(dependencyOrder);
 		}
-		T[] IFrameworkServices.GetTypedDomainModelProviders<T>()
+		T[] IFrameworkServices.GetTypedDomainModelProviders<T>(bool dependencyOrder)
 		{
-			return GetTypedDomainModelProviders<T>();
+			return GetTypedDomainModelProviders<T>(dependencyOrder);
 		}
 		private CopyClosureManager myCopyClosureManager;
 		/// <summary>


### PR DESCRIPTION
Overload the IFrameworkServices.GetTypedDomainModelProviders method to
retrieve models ordered by dependency instead of by the (default) name.
This applies a topological sorting algorithm based on model dependency
attributes on the domain model types.

Add the SoftExtensionDependencyAttribute to allow a model to depend on
a target model when the target model is loaded--without forcing the
target model to load. This attribute is recognized by the dependency
ordering in GetTypedDomainModelProviders. Extensions are identified
by their model id.

Retrieve all uses of the IDynamicShapeColorProvider service with
dependency ordering, with the first model to return a color winning.
This allows multiple extensions to provide colorization with
predictable results based on soft dependencies between the extensions.
