### PR TITLE
Use identifying role instance for implied fact

### DIFF
--- a/ORMModel/ObjectModel/SamplePopulation.cs
+++ b/ORMModel/ObjectModel/SamplePopulation.cs
@@ -6144,6 +6144,11 @@ namespace ORMSolutions.ORMArchitect.Core.ObjectModel
 		/// or <see cref="ObjectifiedUnaryRole"/>.
 		/// </summary>
 		public readonly RoleBase ImpliedProxyRole;
+		/// <summary>
+		/// If this is implied by an entity type and the identifying preferred identifier
+		/// has more than one role then set this to the identifying role in this fact type.
+		/// </summary>
+		public readonly Role ImpliedIdentifyingRole;
 		#endregion // Fields
 		#region Constructor
 		/// <summary>
@@ -6157,6 +6162,7 @@ namespace ORMSolutions.ORMArchitect.Core.ObjectModel
 			ObjectType impliedByEntityType = null;
 			ObjectType identifyingSuperType = null;
 			RoleBase impliedProxyRole = null;
+			Role identifyingRole = null;
 			IList<RoleBase> factRoles;
 			SubtypeFact subtypeFact;
 			Objectification objectification;
@@ -6193,6 +6199,20 @@ namespace ORMSolutions.ORMArchitect.Core.ObjectModel
 							preferredFor.NestedFactType != factType)
 						{
 							identifyingSuperType = impliedByEntityType = preferredFor;
+							LinkedElementCollection<Role> identifyingRoles = uc.RoleCollection;
+							int roleCount = identifyingRoles.Count;
+							if (roleCount > 1)
+							{
+								for (int i = 0; i < roleCount; ++i)
+								{
+									Role testIdentifyingRole = identifyingRoles[i];
+									if (testIdentifyingRole.FactType == factType)
+									{
+										identifyingRole = testIdentifyingRole;
+										break;
+									}
+								}
+							}
 							break;
 						}
 					}
@@ -6201,6 +6221,7 @@ namespace ORMSolutions.ORMArchitect.Core.ObjectModel
 			ImpliedByEntityType = impliedByEntityType;
 			IdentifyingSupertype = identifyingSuperType;
 			ImpliedProxyRole = impliedProxyRole;
+			ImpliedIdentifyingRole = identifyingRole;
 		}
 		#endregion // Constructor
 		#region Accessor Properties

--- a/ORMModel/Shell/SamplePopulationEditor.cs
+++ b/ORMModel/Shell/SamplePopulationEditor.cs
@@ -5100,7 +5100,26 @@ namespace ORMSolutions.ORMArchitect.Core.Shell
 							}
 							else
 							{
-								text = instance.Name;
+								// If this is a compound identifier than get the instance from the correct role.
+								// Otherwise, just use the name of the instance.
+								Role identifyingRole;
+								if (null != (identifyingRole = myImplicationProxy.ImpliedIdentifyingRole) &&
+									ResolveColumn(ref column) == ColumnType.FactType &&
+									identifyingRole == myFactType.OrderedRoleCollection[column])
+								{
+									ObjectTypeInstance resolvedInstance;
+									EntityTypeInstance entityInstance;
+									EntityTypeRoleInstance roleInstance;
+									text = (null != (entityInstance = instance as EntityTypeInstance) &&
+										null != (roleInstance = entityInstance.FindRoleInstance(identifyingRole)) &&
+										null != (resolvedInstance = roleInstance.ObjectTypeInstance)) ?
+											resolvedInstance.Name :
+											string.Empty;
+								}
+								else
+								{
+									text = instance.Name;
+								}
 							}
 						}
 					}


### PR DESCRIPTION
Fixes #13

When a fact type is part of a preferred identifier the population of
the fact type is implied by the population of the identified entity
instance. For a single-role identification scheme the object instance
and its (only) role instance display the same. However, for a compound
identifier we need to display the role instance on the identifying
role, while the identified role keeps the full instance display.

The fix extends the FactTypeInstanceImplication helper struct to
indicate if an identifying role in a compound identifier has been
selected. If this is set and the current column corresponds to the
identifying role then display the role instance instead of the
entity instance.