### PR TITLE
Do not wrap or clip Relational View table names

### DIFF
--- a/AlternateViews/RelationalView/ShapeModel/ColumnElementListCompartment.cs
+++ b/AlternateViews/RelationalView/ShapeModel/ColumnElementListCompartment.cs
@@ -57,7 +57,7 @@ namespace ORMSolutions.ORMArchitect.Views.RelationalView
 		/// <summary>
 		/// The <see cref="T:System.Drawing.StringFormat"/> used to write text for the columns and table name.
 		/// </summary>
-		private static readonly StringFormat DefaultStringFormat = new StringFormat(StringFormatFlags.NoClip);
+		private static readonly StringFormat DefaultStringFormat = new StringFormat(StringFormatFlags.NoClip | StringFormatFlags.NoWrap);
 		/// <summary>
 		/// Specifies a comma string for use with delimiting constraints.
 		/// </summary>
@@ -345,7 +345,7 @@ namespace ORMSolutions.ORMArchitect.Views.RelationalView
 		{
 			DefaultStringFormat.Alignment = StringAlignment.Center;
 			DefaultStringFormat.LineAlignment = StringAlignment.Center;
-			DefaultStringFormat.Trimming = StringTrimming.EllipsisCharacter;
+			DefaultStringFormat.Trimming = StringTrimming.None;
 		}
 		/// <summary>
 		/// Updates the size of this <see cref="T:ORMSolutions.ORMArchitect.Views.RelationalView.ColumnElementListCompartment"/> and

--- a/AlternateViews/RelationalView/ShapeModel/TableShape.cs
+++ b/AlternateViews/RelationalView/ShapeModel/TableShape.cs
@@ -26,6 +26,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Drawing;
 using Microsoft.VisualStudio.Modeling;
 using Microsoft.VisualStudio.Modeling.Diagrams;
 using ORMSolutions.ORMArchitect.Core.ObjectModel;
@@ -76,6 +77,14 @@ namespace ORMSolutions.ORMArchitect.Views.RelationalView
 			textField.DefaultAutoSize = true;
 			textField.AnchoringBehavior.MinimumHeightInLines = 1;
 			textField.AnchoringBehavior.MinimumWidthInCharacters = 1;
+
+			// Header measure can be off by a small amount. This is harmless for display
+			// unless the text is modified (clipped, wrapped, ellipsis, etc.)
+			StringFormat headerFormat = new StringFormat(StringFormatFlags.NoClip | StringFormatFlags.NoWrap);
+			headerFormat.Alignment = StringAlignment.Center;
+			headerFormat.LineAlignment = StringAlignment.Center;
+			headerFormat.Trimming = StringTrimming.None;
+			textField.DefaultStringFormat = headerFormat;
 			textField.DefaultFontId = new StyleSetResourceId(string.Empty, "ShapeTextBold10");
 			shapeFields.Add(textField);
 		}


### PR DESCRIPTION
Fixes #15

Modify the table name text field rendering options to never clip, wrap
or display ellipsis. This could be triggered by small discrepancies in
measuring text that cause overflow pixels that are not visible to the
end user but could still overflow the official boundary and trigger a
text clipping response.