### PR TITLE
Context Window and Generator Settings scaling

### DIFF
--- a/ORMModel/Shell/ORMContextWindow.cs
+++ b/ORMModel/Shell/ORMContextWindow.cs
@@ -91,7 +91,15 @@ namespace ORMSolutions.ORMArchitect.Core.Shell
 
 				myPanel = new System.Windows.Forms.ContainerControl();
 				myPanel.SuspendLayout();
-				Control pnlOption = new System.Windows.Forms.ContainerControl();
+				ContainerControl pnlOption = new System.Windows.Forms.ContainerControl();
+				pnlOption.AutoScaleMode = AutoScaleMode.Font;
+				// Regardless of what I set AutoScaleDimensions to it always has the same value as
+				// CurrentAutoScaleDimensions. Let's hear it for brute-force scaling!
+				//pnlOption.AutoScaleDimensions = new SizeF(6F, 13F);
+				SizeF currentDimensions = pnlOption.CurrentAutoScaleDimensions;
+				float xFactor = currentDimensions.Width / 6F;
+				float yFactor = currentDimensions.Height / 13F;
+				pnlOption.AutoScaleMode = AutoScaleMode.None;
 				Label lblGenerations = new System.Windows.Forms.Label();
 				DiagramView viewControl = myDiagramView;
 				if (viewControl == null)
@@ -107,24 +115,24 @@ namespace ORMSolutions.ORMArchitect.Core.Shell
 				//pnlOption.Dock = System.Windows.Forms.DockStyle.Top;
 				pnlOption.Location = new System.Drawing.Point(0, 0);
 				pnlOption.Name = "Options";
-				pnlOption.Size = new System.Drawing.Size(316, 24);
+				pnlOption.Size = new System.Drawing.Size((int)Math.Ceiling(316 * xFactor), (int)Math.Ceiling(24 * yFactor));
 				pnlOption.Anchor = AnchorStyles.Left | AnchorStyles.Right | AnchorStyles.Top;
 				//pnlOption.TabIndex = 0;
 				// 
 				// lblGenerations
 				// 
 				lblGenerations.AutoSize = true;
-				lblGenerations.Location = new System.Drawing.Point(4, 4);
+				lblGenerations.Location = new System.Drawing.Point((int)Math.Ceiling(4 * xFactor), (int)Math.Ceiling(4 * yFactor));
 				lblGenerations.Name = "lblGenerations";
-				lblGenerations.Size = new System.Drawing.Size(64, 13);
+				lblGenerations.Size = new System.Drawing.Size((int)Math.Ceiling(64 * xFactor), (int)Math.Ceiling(13 * yFactor));
 				lblGenerations.TabIndex = 0;
 				lblGenerations.Text = "Generations";
 				// 
 				// myUpDownGenerations
 				// 
-				myUpDownGenerations.Location = new System.Drawing.Point(73, 1);
+				myUpDownGenerations.Location = new System.Drawing.Point((int)Math.Ceiling(73 * xFactor), (int)Math.Ceiling(1 * yFactor));
 				myUpDownGenerations.Name = "numericUpDown1";
-				myUpDownGenerations.Size = new System.Drawing.Size(50, 20);
+				myUpDownGenerations.Size = new System.Drawing.Size((int)Math.Ceiling(50 * xFactor), (int)Math.Ceiling(20 * yFactor));
 				myUpDownGenerations.TabIndex = 1;
 				myUpDownGenerations.Minimum = 0;
 				myUpDownGenerations.Maximum = 3;
@@ -133,8 +141,8 @@ namespace ORMSolutions.ORMArchitect.Core.Shell
 				// 
 				// viewControl
 				// 
-				viewControl.Size = new Size(myPanel.ClientSize.Width, myPanel.ClientSize.Height - 24);
-				viewControl.Location = new Point(0, 24);
+				viewControl.Size = new Size(myPanel.ClientSize.Width, myPanel.ClientSize.Height - pnlOption.Height);
+				viewControl.Location = new Point(0, pnlOption.Height);
 				viewControl.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Right | AnchorStyles.Left;
 				//
 				// myPanel

--- a/Tools/ORMCustomTool/UI/ORMGeneratorSelectionControl.Designer.cs
+++ b/Tools/ORMCustomTool/UI/ORMGeneratorSelectionControl.Designer.cs
@@ -97,10 +97,10 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 			// ORMGeneratorSelectionControl
 			// 
 			this.AcceptButton = this.button_SaveChanges;
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Inherit;
+			resources.ApplyResources(this, "$this");
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
 			this.BackColor = System.Drawing.SystemColors.Control;
 			this.CancelButton = this.button_Cancel;
-			resources.ApplyResources(this, "$this");
 			this.Controls.Add(this.button_SaveChanges);
 			this.Controls.Add(this.button_Cancel);
 			this.Controls.Add(this.textBox_ORMFileName);

--- a/Tools/ORMCustomTool/UI/ORMGeneratorSelectionControl.resx
+++ b/Tools/ORMCustomTool/UI/ORMGeneratorSelectionControl.resx
@@ -267,6 +267,9 @@
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
     <value>632, 446</value>
   </data>


### PR DESCRIPTION
Fixes #21

The ORM Context Window creates the controls at the top of the window
with custom code, not with designer-generated files. I could not get
AutoScaling to trigger automatically with this approach. However, I
can get the value for the current font size and add custom scaling.
The Generations label and spinner controls now have enough vertical
space and no longer overlap.

The ORM Generator Settings control was also not scaling properly. This
was fixed by setting the AutoScaleMode to Font instead of Inherit.