### PR TITLE
Generate multiple files with one output format

### DIFF
--- a/AlternateViews/BarkerERView/EntityRelationship.SerializationExtensions.cs
+++ b/AlternateViews/BarkerERView/EntityRelationship.SerializationExtensions.cs
@@ -24,7 +24,7 @@ using ORMSolutions.ORMArchitect.Framework.Shell;
 namespace ORMSolutions.ORMArchitect.Views.BarkerERView
 {
 	#region BarkerERShapeDomainModel model serialization
-	[CustomSerializedXmlNamespaces("http://schemas.neumont.edu/ORM/2008-05/BarkerERView")]
+	[CustomSerializedXmlSchema("http://schemas.neumont.edu/ORM/2008-05/BarkerERView", "BarkerERView.xsd")]
 	partial class BarkerERShapeDomainModel : ICustomSerializedDomainModel
 	{
 		/// <summary>The default XmlNamespace associated with the 'BarkerERShapeDomainModel' extension model</summary>

--- a/AlternateViews/RelationalView/RelationalShape.SerializationExtensions.cs
+++ b/AlternateViews/RelationalView/RelationalShape.SerializationExtensions.cs
@@ -24,7 +24,7 @@ using ORMSolutions.ORMArchitect.Framework.Shell;
 namespace ORMSolutions.ORMArchitect.Views.RelationalView
 {
 	#region RelationalShapeDomainModel model serialization
-	[CustomSerializedXmlNamespaces("http://schemas.neumont.edu/ORM/2007-11/RelationalView")]
+	[CustomSerializedXmlSchema("http://schemas.neumont.edu/ORM/2007-11/RelationalView", "RelationalView.xsd")]
 	partial class RelationalShapeDomainModel : ICustomSerializedDomainModel
 	{
 		/// <summary>The default XmlNamespace associated with the 'RelationalShapeDomainModel' extension model</summary>

--- a/CustomProperties/CustomProperty.SerializationExtensions.cs
+++ b/CustomProperties/CustomProperty.SerializationExtensions.cs
@@ -25,7 +25,7 @@ using ORMSolutions.ORMArchitect.Framework.Shell;
 namespace ORMSolutions.ORMArchitect.CustomProperties
 {
 	#region CustomPropertiesDomainModel model serialization
-	[CustomSerializedXmlNamespaces("http://schemas.neumont.edu/ORM/2007-11/CustomProperties")]
+	[CustomSerializedXmlSchema("http://schemas.neumont.edu/ORM/2007-11/CustomProperties", "CustomProperties.xsd")]
 	sealed partial class CustomPropertiesDomainModel : ICustomSerializedDomainModel
 	{
 		/// <summary>The default XmlNamespace associated with the 'CustomPropertiesDomainModel' extension model</summary>

--- a/EntityRelationship/BarkerErModel/BerModel.SerializationExtensions.cs
+++ b/EntityRelationship/BarkerErModel/BerModel.SerializationExtensions.cs
@@ -24,7 +24,7 @@ using ORMSolutions.ORMArchitect.Framework.Shell;
 namespace ORMSolutions.ORMArchitect.EntityRelationshipModels.Barker
 {
 	#region BarkerDomainModel model serialization
-	[CustomSerializedXmlNamespaces("http://schemas.neumont.edu/ORM/EntityRelationship/2008-05/Barker")]
+	[CustomSerializedXmlSchema("http://schemas.neumont.edu/ORM/EntityRelationship/2008-05/Barker", "BarkerERModel.xsd")]
 	partial class BarkerDomainModel : ICustomSerializedDomainModel
 	{
 		/// <summary>The default XmlNamespace associated with the 'BarkerDomainModel' extension model</summary>
@@ -374,7 +374,7 @@ namespace ORMSolutions.ORMArchitect.EntityRelationshipModels.Barker
 			}
 			if (roleId == EntityTypeIsSubtypeOfEntityType.SupertypeDomainRoleId)
 			{
-				return new CustomSerializedElementInfo(null, null, null, CustomSerializedElementWriteStyle.NotWritten, null);
+				return CustomSerializedElementInfo.NotWritten;
 			}
 			return CustomSerializedElementInfo.Default;
 		}
@@ -797,17 +797,9 @@ namespace ORMSolutions.ORMArchitect.EntityRelationshipModels.Barker
 		protected CustomSerializedElementInfo GetCustomSerializedLinkInfo(DomainRoleInfo rolePlayedInfo, ElementLink elementLink)
 		{
 			Guid roleId = rolePlayedInfo.Id;
-			if (roleId == BinaryAssociationContainsRole.BinaryAssociationDomainRoleId)
+			if (roleId == BinaryAssociationContainsRole.BinaryAssociationDomainRoleId || roleId == EntityTypePlaysRole.EntityTypeDomainRoleId || roleId == ExclusiveArcSpansOptionalRole.ExclusiveArcDomainRoleId)
 			{
-				return new CustomSerializedElementInfo(null, null, null, CustomSerializedElementWriteStyle.NotWritten, null);
-			}
-			if (roleId == EntityTypePlaysRole.EntityTypeDomainRoleId)
-			{
-				return new CustomSerializedElementInfo(null, null, null, CustomSerializedElementWriteStyle.NotWritten, null);
-			}
-			if (roleId == ExclusiveArcSpansOptionalRole.ExclusiveArcDomainRoleId)
-			{
-				return new CustomSerializedElementInfo(null, null, null, CustomSerializedElementWriteStyle.NotWritten, null);
+				return CustomSerializedElementInfo.NotWritten;
 			}
 			return CustomSerializedElementInfo.Default;
 		}

--- a/EntityRelationship/OialBerBridge/OialBerBridge.SerializationExtensions.cs
+++ b/EntityRelationship/OialBerBridge/OialBerBridge.SerializationExtensions.cs
@@ -24,7 +24,7 @@ using ORMSolutions.ORMArchitect.Framework.Shell;
 namespace ORMSolutions.ORMArchitect.ORMAbstractionToBarkerERBridge
 {
 	#region ORMAbstractionToBarkerERBridgeDomainModel model serialization
-	[CustomSerializedXmlNamespaces("http://schemas.neumont.edu/ORM/Bridge/2008-05/ORMAbstractionToBarkerER")]
+	[CustomSerializedXmlSchema("http://schemas.neumont.edu/ORM/Bridge/2008-05/ORMAbstractionToBarkerER", "ORMAbstractionToBarkerERBridge.xsd")]
 	partial class ORMAbstractionToBarkerERBridgeDomainModel : ICustomSerializedDomainModel
 	{
 		/// <summary>The default XmlNamespace associated with the 'ORMAbstractionToBarkerERBridgeDomainModel' extension model</summary>

--- a/ExtensionExample/ExtensionDomainModel.SerializationExtensions.cs
+++ b/ExtensionExample/ExtensionDomainModel.SerializationExtensions.cs
@@ -24,7 +24,7 @@ using ORMSolutions.ORMArchitect.Framework.Shell;
 namespace ORMSolutions.ORMArchitect.ExtensionExample
 {
 	#region ExtensionDomainModel model serialization
-	[CustomSerializedXmlNamespaces("http://schemas.neumont.edu/ORM/ExtensionExample")]
+	[CustomSerializedXmlSchema("http://schemas.neumont.edu/ORM/ExtensionExample", "ExtensionDomainModelTest.xsd")]
 	partial class ExtensionDomainModel : ICustomSerializedDomainModel
 	{
 		/// <summary>The default XmlNamespace associated with the 'ExtensionDomainModel' extension model</summary>

--- a/OIALModel/OIALModel.SerializationExtensions.cs
+++ b/OIALModel/OIALModel.SerializationExtensions.cs
@@ -24,7 +24,7 @@ using ORMSolutions.ORMArchitect.Framework.Shell;
 namespace Neumont.Tools.ORM.OIALModel
 {
 	#region OIALDomainModel model serialization
-	[CustomSerializedXmlNamespaces("http://schemas.neumont.edu/ORM/2006-01/OIALModel")]
+	[CustomSerializedXmlSchema("http://schemas.neumont.edu/ORM/2006-01/OIALModel", "OIALModel.xsd")]
 	partial class OIALDomainModel : ICustomSerializedDomainModel
 	{
 		/// <summary>The default XmlNamespace associated with the 'OIALDomainModel' extension model</summary>
@@ -310,11 +310,8 @@ namespace Neumont.Tools.ORM.OIALModel
 				match.InitializeRoles(OIALModelHasORMModel.ORMModelDomainRoleId);
 				childElementMappings.Add("||||http://schemas.neumont.edu/ORM/2006-01/OIALModel|ORMModel", match);
 				match.InitializeRoles(OIALHasInformationTypeFormat.InformationTypeFormatDomainRoleId);
-				childElementMappings.Add("||http://schemas.neumont.edu/ORM/2006-01/OIALModel|InformationTypeFormats||", match);
 				match.InitializeRoles(OIALModelHasConceptType.ConceptTypeDomainRoleId);
-				childElementMappings.Add("||http://schemas.neumont.edu/ORM/2006-01/OIALModel|ConceptTypes||", match);
 				match.InitializeRoles(OIALModelHasChildSequenceConstraint.ChildSequenceConstraintDomainRoleId);
-				childElementMappings.Add("||http://schemas.neumont.edu/ORM/2006-01/OIALModel|ChildSequenceConstraints||", match);
 				OIALModel.myChildElementMappings = childElementMappings;
 			}
 			CustomSerializedElementMatch rVal;
@@ -410,7 +407,7 @@ namespace Neumont.Tools.ORM.OIALModel
 			Guid roleId = rolePlayedInfo.Id;
 			if (roleId == ChildHasSingleChildConstraint.ConceptTypeChildDomainRoleId)
 			{
-				return new CustomSerializedElementInfo(null, null, null, CustomSerializedElementWriteStyle.NotWritten, null);
+				return CustomSerializedElementInfo.NotWritten;
 			}
 			return CustomSerializedElementInfo.Default;
 		}
@@ -882,13 +879,9 @@ namespace Neumont.Tools.ORM.OIALModel
 			{
 				return new CustomSerializedElementInfo(null, "ValueType", null, CustomSerializedElementWriteStyle.Element, null);
 			}
-			if (roleId == InformationType.ConceptTypeDomainRoleId)
+			if (roleId == InformationType.ConceptTypeDomainRoleId || roleId == ConceptTypeChild.ParentDomainRoleId)
 			{
-				return new CustomSerializedElementInfo(null, "ConceptType", null, CustomSerializedElementWriteStyle.NotWritten, null);
-			}
-			if (roleId == ConceptTypeChild.ParentDomainRoleId)
-			{
-				return new CustomSerializedElementInfo(null, "ConceptTypeChild", null, CustomSerializedElementWriteStyle.NotWritten, null);
+				return CustomSerializedElementInfo.NotWritten;
 			}
 			return CustomSerializedElementInfo.Default;
 		}
@@ -1031,17 +1024,9 @@ namespace Neumont.Tools.ORM.OIALModel
 			{
 				return new CustomSerializedElementInfo(null, "InformationType", null, CustomSerializedElementWriteStyle.PrimaryLinkElement, null);
 			}
-			if (roleId == ConceptTypeRef.ReferencingConceptTypeDomainRoleId)
+			if (roleId == ConceptTypeRef.ReferencingConceptTypeDomainRoleId || roleId == ConceptTypeChild.ParentDomainRoleId || roleId == ConceptTypeChild.TargetDomainRoleId)
 			{
-				return new CustomSerializedElementInfo(null, null, null, CustomSerializedElementWriteStyle.NotWritten, null);
-			}
-			if (roleId == ConceptTypeChild.ParentDomainRoleId)
-			{
-				return new CustomSerializedElementInfo(null, "Parent", null, CustomSerializedElementWriteStyle.NotWritten, null);
-			}
-			if (roleId == ConceptTypeChild.TargetDomainRoleId)
-			{
-				return new CustomSerializedElementInfo(null, "Target", null, CustomSerializedElementWriteStyle.NotWritten, null);
+				return CustomSerializedElementInfo.NotWritten;
 			}
 			return CustomSerializedElementInfo.Default;
 		}
@@ -1233,13 +1218,13 @@ namespace Neumont.Tools.ORM.OIALModel
 		protected CustomSerializedElementInfo GetCustomSerializedLinkInfo(DomainRoleInfo rolePlayedInfo, ElementLink elementLink)
 		{
 			Guid roleId = rolePlayedInfo.Id;
-			if (roleId == ChildSequenceHasConceptTypeChild.ChildSequenceDomainRoleId)
-			{
-				return new CustomSerializedElementInfo(null, null, null, CustomSerializedElementWriteStyle.NotWritten, null);
-			}
 			if (roleId == ConceptTypeChildHasPathRole.PathRoleDomainRoleId)
 			{
 				return new CustomSerializedElementInfo("orm", "Role", null, CustomSerializedElementWriteStyle.Element, null);
+			}
+			if (roleId == ChildSequenceHasConceptTypeChild.ChildSequenceDomainRoleId)
+			{
+				return CustomSerializedElementInfo.NotWritten;
 			}
 			return CustomSerializedElementInfo.Default;
 		}

--- a/ORMModel/Framework/FrameworkServices.cs
+++ b/ORMModel/Framework/FrameworkServices.cs
@@ -253,7 +253,16 @@ namespace ORMSolutions.ORMArchitect.Framework
 		/// <summary>
 		/// Create a <see cref="AlsoLoadDomainModelAttribute"/> for a specific domain model.
 		/// </summary>
-		public AlsoLoadDomainModelAttribute(string namespaceURI, Type type, bool isNonGenerative = false)
+		public AlsoLoadDomainModelAttribute(string namespaceURI, Type type)
+		{
+			myAlsoLoadType = type;
+			myNamespaceURI = namespaceURI;
+			myIsNonGenerative = false;
+		}
+		/// <summary>
+		/// Create a <see cref="AlsoLoadDomainModelAttribute"/> for a specific domain model.
+		/// </summary>
+		public AlsoLoadDomainModelAttribute(string namespaceURI, Type type, bool isNonGenerative)
 		{
 			myAlsoLoadType = type;
 			myNamespaceURI = namespaceURI;

--- a/ORMModel/Framework/Shell/DiagramDisplay.SerializationExtensions.cs
+++ b/ORMModel/Framework/Shell/DiagramDisplay.SerializationExtensions.cs
@@ -24,7 +24,7 @@ using ORMSolutions.ORMArchitect.Framework.Shell;
 namespace ORMSolutions.ORMArchitect.Framework.Shell
 {
 	#region DiagramDisplayDomainModel model serialization
-	[CustomSerializedXmlNamespaces("http://schemas.neumont.edu/ORM/2008-11/DiagramDisplay")]
+	[CustomSerializedXmlSchema("http://schemas.neumont.edu/ORM/2008-11/DiagramDisplay", "DiagramDisplay.xsd")]
 	partial class DiagramDisplayDomainModel : ICustomSerializedDomainModel
 	{
 		/// <summary>The default XmlNamespace associated with the 'DiagramDisplayDomainModel' extension model</summary>

--- a/ORMModel/Framework/Shell/SerializationEngine.cs
+++ b/ORMModel/Framework/Shell/SerializationEngine.cs
@@ -211,7 +211,7 @@ namespace ORMSolutions.ORMArchitect.Framework.Shell
 	#endregion // CustomSerializedElementMatchStyle enum
 	#region SerializationEngineLoadOptions enum
 	/// <summary>
-	/// Options modifying the behavior of <see cref="SerializationEngine.Load"/>.
+	/// Options modifying the behavior of <see cref="SerializationEngine.Load(System.IO.Stream,SerializationEngineLoadOptions)"/>.
 	/// </summary>
 	[Flags]
 	public enum SerializationEngineLoadOptions
@@ -1613,7 +1613,7 @@ namespace ORMSolutions.ORMArchitect.Framework.Shell
 	/// non-generative extensions such as models used for display or editing of
 	/// models and diagrams but not for code generation. This will be checked if
 	/// the <see cref="SerializationEngineLoadOptions.ResolveSkippedExtensions"/>
-	/// flag is set on the call to <see cref="SerializationEngine.Load"/>
+	/// flag is set on the call to <see cref="SerializationEngine.Load(System.IO.Stream,SerializationEngineLoadOptions)"/>
 	/// </summary>
 	public interface ISkipExtensions
 	{
@@ -3621,8 +3621,16 @@ namespace ORMSolutions.ORMArchitect.Framework.Shell
 		/// Load the stream contents into the current store
 		/// </summary>
 		/// <param name="stream">An initialized stream</param>
+		public void Load(Stream stream)
+		{
+			Load(stream, SerializationEngineLoadOptions.None);
+		}
+		/// <summary>
+		/// Load the stream contents into the current store
+		/// </summary>
+		/// <param name="stream">An initialized stream</param>
 		/// <param name="options">Options to modify load behavior. Defaults to <see cref="SerializationEngineLoadOptions.None"/></param>
-		public void Load(Stream stream, SerializationEngineLoadOptions options = SerializationEngineLoadOptions.None)
+		public void Load(Stream stream, SerializationEngineLoadOptions options)
 		{
 			DeserializationFixupManager fixupManager = new DeserializationFixupManager(myStore);
 			myNotifyAdded = fixupManager as INotifyElementAdded;

--- a/ORMModel/Load/ExtensionLoader.cs
+++ b/ORMModel/Load/ExtensionLoader.cs
@@ -282,7 +282,7 @@ namespace ORMSolutions.ORMArchitect.Core.Load
 					}
 				}
 
-#pragma warning disable CS0618
+#pragma warning disable 618
 				// UNDONE: Remove CustomSerializedXmlNamespacesAttribute support
 				if (!foundMatch)
 				{
@@ -299,7 +299,7 @@ namespace ORMSolutions.ORMArchitect.Core.Load
 						}
 					}
 				}
-#pragma warning restore CS0618
+#pragma warning restore 618
 
 				if (!foundMatch)
 				{
@@ -637,7 +637,7 @@ namespace ORMSolutions.ORMArchitect.Core.Load
 			IDictionary<string, ExtensionModelBinding> originalAvailableExtensions = fullLoader.myAvailableExtensions;
 			foreach (ExtensionModelBinding binding in originalAvailableExtensions.Values)
 			{
-				fullLoader.TestIsNonGenerativeBinding(binding, nonGenerativeIds);
+				fullLoader.TestIsNonGenerativeBinding(binding, nonGenerativeIds, false);
 			}
 
 			// Set available extensions
@@ -701,7 +701,7 @@ namespace ORMSolutions.ORMArchitect.Core.Load
 			}
 			myAutoLoadExtensions = newAutoLoads ?? new string[0];
 		}
-		private bool TestIsNonGenerativeBinding(ExtensionModelBinding binding, Dictionary<Guid, bool> nonGenerativeIds, bool forceNonGenerative = false)
+		private bool TestIsNonGenerativeBinding(ExtensionModelBinding binding, Dictionary<Guid, bool> nonGenerativeIds, bool forceNonGenerative)
 		{
 			bool isNonGenerative;
 			Guid modelId = binding.DomainModelId;
@@ -736,7 +736,7 @@ namespace ORMSolutions.ORMArchitect.Core.Load
 						if (myExtensionIdToExtensionNameMap.TryGetValue(extendsId, out extensionName) &&
 							myAvailableExtensions.TryGetValue(extensionName, out extensionBinding))
 						{
-							if (TestIsNonGenerativeBinding(extensionBinding, nonGenerativeIds))
+							if (TestIsNonGenerativeBinding(extensionBinding, nonGenerativeIds, false))
 							{
 								nonGenerativeIds[modelId] = isNonGenerative = true;
 								break;
@@ -1338,7 +1338,7 @@ namespace ORMSolutions.ORMArchitect.Core.Load
 				}
 			}
 
-#pragma warning disable CS0618
+#pragma warning disable 618
 			// UNDONE: Remove CustomSerializedXmlNamespacesAttribute support
 			List<CustomSerializedXmlNamespacesAttribute> namespaceAttributes = new List<CustomSerializedXmlNamespacesAttribute>();
 			foreach (Type standardType in standardTypes)
@@ -1373,7 +1373,7 @@ namespace ORMSolutions.ORMArchitect.Core.Load
 					namespaceList.Add(currentAttribute[j]);
 				}
 			}
-#pragma warning restore CS0618
+#pragma warning restore 618
 
 			string[] namespaces = new string[namespaceList.Count];
 			namespaceList.CopyTo(namespaces);

--- a/ORMModel/Load/ExtensionLoader.cs
+++ b/ORMModel/Load/ExtensionLoader.cs
@@ -49,16 +49,24 @@ namespace ORMSolutions.ORMArchitect.Core.Load
 		/// <summary>
 		/// No special options are applied
 		/// </summary>
-		None,
+		None = 0,
 		/// <summary>
 		/// The extension model loads automatically as part
 		/// of another model, should not be displayed to the user.
 		/// </summary>
-		Secondary,
+		Secondary = 1,
 		/// <summary>
 		/// The extension model should always be loaded.
 		/// </summary>
-		AutoLoad,
+		AutoLoad = 2,
+		/// <summary>
+		/// The extension model should not be loaded if the document is loaded
+		/// solely for code generation. This overrides the <see cref="ExtensionModelOptions.AutoLoad"/>
+		/// flag and is generally used for models associated with displaying diagrams or
+		/// other displayed elements. If a model references a non-generative model then it should
+		/// also be set accordingly.
+		/// </summary>
+		NonGenerative = 4,
 	}
 	#endregion // ExtensionModelOptions enum
 	#region ExtensionModelData struct
@@ -164,6 +172,11 @@ namespace ORMSolutions.ORMArchitect.Core.Load
 								{
 									options |= ExtensionModelOptions.AutoLoad;
 								}
+								valueObject = extensionKey.GetValue("NonGenerative");
+								if (valueObject != null && ((int)valueObject) == 1)
+								{
+									options |= ExtensionModelOptions.NonGenerative;
+								}
 								(retVal ?? (retVal = new List<ExtensionModelData>())).Add(new ExtensionModelData(
 									extensionNamespace,
 									extensionKey.GetValue("CodeBase") as string,
@@ -254,24 +267,45 @@ namespace ORMSolutions.ORMArchitect.Core.Load
 			// Verify that if the domain serializes elements, then it serializes this one
 			if (0 == (options & ExtensionModelOptions.AutoLoad))
 			{
-				object[] namespaceAttributes = type.GetCustomAttributes(typeof(CustomSerializedXmlNamespacesAttribute), false);
-				if (namespaceAttributes != null && namespaceAttributes.Length != 0)
+				object[] namespaceAttributes = type.GetCustomAttributes(typeof(CustomSerializedXmlSchemaAttribute), false);
+				bool foundMatch = false;
+				int count;
+				if (namespaceAttributes != null && (count = namespaceAttributes.Length) != 0)
 				{
-					bool foundMatch = false;
-					foreach (string testNamespace in (CustomSerializedXmlNamespacesAttribute)namespaceAttributes[0])
+					for (int i = 0; i < count; ++i)
 					{
-						if (testNamespace == namespaceUri)
+						if (((CustomSerializedXmlSchemaAttribute)namespaceAttributes[i]).XmlNamespace == namespaceUri)
 						{
 							foundMatch = true;
 							break;
 						}
 					}
-					if (!foundMatch)
+				}
+
+#pragma warning disable CS0618
+				// UNDONE: Remove CustomSerializedXmlNamespacesAttribute support
+				if (!foundMatch)
+				{
+					namespaceAttributes = type.GetCustomAttributes(typeof(CustomSerializedXmlNamespacesAttribute), false);
+					if (namespaceAttributes != null && namespaceAttributes.Length != 0)
 					{
-						// Bogus request, return and leave IsValidExtension false
-						this = default(ExtensionModelBinding);
-						return;
+						foreach (string testNamespace in (CustomSerializedXmlNamespacesAttribute)namespaceAttributes[0])
+						{
+							if (testNamespace == namespaceUri)
+							{
+								foundMatch = true;
+								break;
+							}
+						}
 					}
+				}
+#pragma warning restore CS0618
+
+				if (!foundMatch)
+				{
+					// Bogus request, return and leave IsValidExtension false
+					this = default(ExtensionModelBinding);
+					return;
 				}
 			}
 			this.myNamespaceUri = namespaceUri;
@@ -391,6 +425,19 @@ namespace ORMSolutions.ORMArchitect.Core.Load
 				return 0 != (myOptions & ExtensionModelOptions.AutoLoad);
 			}
 		}
+		/// <summary>
+		/// True if the extension is not needed for code generation scenarios.
+		/// Generally used for extensions that contribute display or editing elements.
+		/// This takes precedence over <see cref="IsAutoLoad"/> for models loaded
+		/// specifically for code generation.
+		/// </summary>
+		public bool IsNonGenerative
+		{
+			get
+			{
+				return 0 != (myOptions & ExtensionModelOptions.NonGenerative);
+			}
+		}
 		/// <summary>See <see cref="Object.Equals(Object)"/>.</summary>
 		public override bool Equals(object obj)
 		{
@@ -433,6 +480,7 @@ namespace ORMSolutions.ORMArchitect.Core.Load
 		private IDictionary<Guid, string> myExtensionIdToExtensionNameMap;
 		private readonly IDictionary<Guid, Type> myStandardDomainModelsMap;
 		private IDictionary<string, Exception> myUnloadableExtensionErrors;
+		private ExtensionLoader myNonGenerativeLoader;
 		#endregion // Member Variables
 		#region Constructor
 		/// <summary>
@@ -556,8 +604,179 @@ namespace ORMSolutions.ORMArchitect.Core.Load
 			};
 		}
 		/// <summary>
-		/// Helper for the constructor to resolve <see cref="AlsoLoadDomainModelAttribute"/>
+		/// Private entry point used to create the non-generative loader
+		/// from a full loader.
 		/// </summary>
+		private ExtensionLoader(ExtensionLoader fullLoader)
+		{
+			// Return previously reduced set on deeper request
+			myNonGenerativeLoader = this;
+			myExtensionIdToExtensionNameMap = fullLoader.myExtensionIdToExtensionNameMap; // This may be too big, but is harmless
+
+			// Make this recursive, so models that depend on non-generative models are
+			// automatically removed as well as any 'also loaded' models. This reduces
+			// the number of models we need to explicitly register as non-generative.
+			// A false value here indicates that the model is currently being processed
+			// and is meant to block uncontrolled recursion.
+			Dictionary<Guid, bool> nonGenerativeIds = new Dictionary<Guid, bool>();
+
+			// Standard models are very limited in this mode
+			Dictionary<Guid, Type> standardModels = new Dictionary<Guid, Type>(2);
+			standardModels.Add(ORMSolutions.ORMArchitect.Framework.FrameworkDomainModel.DomainModelId, typeof(ORMSolutions.ORMArchitect.Framework.FrameworkDomainModel));
+			standardModels.Add(ORMSolutions.ORMArchitect.Core.ObjectModel.ORMCoreDomainModel.DomainModelId, typeof(ORMSolutions.ORMArchitect.Core.ObjectModel.ORMCoreDomainModel));
+
+			// The other standard models are considered non-generative
+			nonGenerativeIds.Add(Microsoft.VisualStudio.Modeling.Diagrams.CoreDesignSurfaceDomainModel.DomainModelId, true);
+			nonGenerativeIds.Add(ORMSolutions.ORMArchitect.Core.ShapeModel.ORMShapeDomainModel.DomainModelId, true);
+			// UNDONE: Temporary. See comment in other constructor
+			nonGenerativeIds.Add(ObjectModel.Verbalization.HtmlReport.DomainModelId, true);
+			nonGenerativeIds.Add(ORMSolutions.ORMArchitect.Framework.Shell.DiagramSurvey.DomainModelId, true);
+			myStandardDomainModelsMap = standardModels;
+
+			// Recursively get non-generative binding information for all extensions
+			IDictionary<string, ExtensionModelBinding> originalAvailableExtensions = fullLoader.myAvailableExtensions;
+			foreach (ExtensionModelBinding binding in originalAvailableExtensions.Values)
+			{
+				fullLoader.TestIsNonGenerativeBinding(binding, nonGenerativeIds);
+			}
+
+			// Set available extensions
+			Dictionary<string, ExtensionModelBinding> availableExtensions = new Dictionary<string, ExtensionModelBinding>();
+			foreach (KeyValuePair<string, ExtensionModelBinding> kvp in originalAvailableExtensions)
+			{
+				bool isNonGenerative;
+				if (!nonGenerativeIds.TryGetValue(kvp.Value.DomainModelId, out isNonGenerative) || !isNonGenerative)
+				{
+					availableExtensions[kvp.Key] = kvp.Value;
+				}
+			}
+			myAvailableExtensions = availableExtensions;
+
+			// Fill in autoload settings
+			string[] originalAutoLoads = fullLoader.myAutoLoadExtensions;
+			string[] newAutoLoads = null;
+			if (originalAutoLoads != null)
+			{
+				int originalAutoLoadCount = originalAutoLoads.Length;
+				if (originalAutoLoadCount != 0)
+				{
+					int newAutoLoadCount = originalAutoLoadCount;
+					BitTracker nonGenerativeTracker = new BitTracker(originalAutoLoadCount);
+					ExtensionModelBinding binding;
+					bool isNonGenerative;
+					for (int i = 0; i < originalAutoLoadCount; ++i)
+					{
+						if (originalAvailableExtensions.TryGetValue(originalAutoLoads[i], out binding) &&
+							nonGenerativeIds.TryGetValue(binding.DomainModelId, out isNonGenerative) &&
+							isNonGenerative)
+						{
+							if (--newAutoLoadCount == 0)
+							{
+								break;
+							}
+							nonGenerativeTracker[i] = true;
+						}
+					}
+
+					if (newAutoLoadCount != 0)
+					{
+						if (newAutoLoadCount == originalAutoLoadCount)
+						{
+							newAutoLoads = originalAutoLoads;
+						}
+						else
+						{
+							newAutoLoads = new string[newAutoLoadCount];
+							for (int i = 0, newIndex = 0; i < originalAutoLoadCount; ++i)
+							{
+								if (!nonGenerativeTracker[i])
+								{
+									newAutoLoads[newIndex] = originalAutoLoads[i];
+									++newIndex;
+								}
+							}
+						}
+					}
+				}
+			}
+			myAutoLoadExtensions = newAutoLoads ?? new string[0];
+		}
+		private bool TestIsNonGenerativeBinding(ExtensionModelBinding binding, Dictionary<Guid, bool> nonGenerativeIds, bool forceNonGenerative = false)
+		{
+			bool isNonGenerative;
+			Guid modelId = binding.DomainModelId;
+			if (nonGenerativeIds.TryGetValue(binding.DomainModelId, out isNonGenerative))
+			{
+				return isNonGenerative;
+			}
+
+			isNonGenerative = forceNonGenerative || binding.IsNonGenerative;
+			nonGenerativeIds[modelId] = isNonGenerative; // Defensive, block recursion
+			string extensionName;
+			ExtensionModelBinding extensionBinding;
+			if (!isNonGenerative)
+			{
+				ICollection<Guid> extends = binding.ExtendsDomainModelIds;
+				if (extends != null && extends.Count != 0)
+				{
+					foreach (Guid extendsId in extends)
+					{
+						// Note that we enter all standard non-generative ids up front, so we only recurse
+						// on non-standard extensions.
+						bool knownNonGenerativeId;
+						if (nonGenerativeIds.TryGetValue(extendsId, out knownNonGenerativeId))
+						{
+							if (knownNonGenerativeId)
+							{
+								nonGenerativeIds[modelId] = isNonGenerative = true;
+								break;
+							}
+						}
+
+						if (myExtensionIdToExtensionNameMap.TryGetValue(extendsId, out extensionName) &&
+							myAvailableExtensions.TryGetValue(extensionName, out extensionBinding))
+						{
+							if (TestIsNonGenerativeBinding(extensionBinding, nonGenerativeIds))
+							{
+								nonGenerativeIds[modelId] = isNonGenerative = true;
+								break;
+							}
+						}
+					}
+				}
+			}
+
+			if (isNonGenerative)
+			{
+				// Also remove 'also loaded' models.
+				ICollection<Guid> alsoLoadIds = binding.AlsoLoadIds;
+				if (alsoLoadIds != null && alsoLoadIds.Count != 0)
+				{
+					foreach (Guid alsoLoadId in alsoLoadIds)
+					{
+						bool alsoLoadNonGenerative;
+						if (nonGenerativeIds.TryGetValue(alsoLoadId, out alsoLoadNonGenerative))
+						{
+							if (alsoLoadNonGenerative)
+							{
+								continue;
+							}
+							nonGenerativeIds.Remove(alsoLoadId);
+						}
+
+						if (myExtensionIdToExtensionNameMap.TryGetValue(alsoLoadId, out extensionName) &&
+							myAvailableExtensions.TryGetValue(extensionName, out extensionBinding))
+						{
+							TestIsNonGenerativeBinding(extensionBinding, nonGenerativeIds, true);
+						}
+					}
+				}
+			}
+			return isNonGenerative;
+		}
+		/// <summary>
+		/// Helper for the constructor to resolve <see cref="AlsoLoadDomainModelAttribute"/>
+		/// </summary>,
 		/// <param name="expandExtension">Get additional domain models for this extension.</param>
 		/// <param name="availableExtensions">The currently known domain models. A previously-bound extension
 		/// will not be reprocessed.</param>
@@ -576,7 +795,7 @@ namespace ORMSolutions.ORMArchitect.Core.Load
 					ExtensionModelBinding alsoBound;
 					if (!string.IsNullOrEmpty(testURI) &&
 						!availableExtensions.ContainsKey(testURI) &&
-						(alsoBound = new ExtensionModelBinding(testURI, alsoLoad.AlsoLoadType, ExtensionModelOptions.Secondary)).IsValidExtension)
+						(alsoBound = new ExtensionModelBinding(testURI, alsoLoad.AlsoLoadType, ExtensionModelOptions.Secondary | (alsoLoad.IsNonGenerative ? ExtensionModelOptions.NonGenerative : ExtensionModelOptions.None))).IsValidExtension)
 					{
 						// Record and recurse
 						(alsoLoadedIds ?? (alsoLoadedIds = new List<Guid>())).Add(alsoBound.DomainModelId);
@@ -861,6 +1080,24 @@ namespace ORMSolutions.ORMArchitect.Core.Load
 			return false;
 		}
 		#endregion // Methods
+		#region NonGenerative Models
+		/// <summary>
+		/// Get the set of extensions that are used for code generation
+		/// but not for display purposes.
+		/// </summary>
+		public ExtensionLoader NonGenerativeLoader
+		{
+			get
+			{
+				ExtensionLoader loader = myNonGenerativeLoader;
+				if (loader == null)
+				{
+					myNonGenerativeLoader = loader = new ExtensionLoader(this);
+				}
+				return loader;
+			}
+		}
+		#endregion // NonGenerative Models
 		#region Extension Stripping
 		#region ExtensionStripperUtility class
 		/// <summary>
@@ -1076,48 +1313,70 @@ namespace ORMSolutions.ORMArchitect.Core.Load
 			// extension types. The serialization engine does not serialize elements
 			// for types without a serialization attribute, so there is no need to
 			// look at standard or extension types without this attribute.
-			CustomSerializedXmlNamespacesAttribute[] namespaceAttributes = new CustomSerializedXmlNamespacesAttribute[extensionTypes.Count + standardTypes.Count];
-			int totalNamespaceCount = 0;
-			int serializedAttributeCount = 0;
+			List<string> namespaceList = new List<string>();
+			foreach (Type standardType in standardTypes)
+			{
+				object[] attributes = standardType.GetCustomAttributes(typeof(CustomSerializedXmlSchemaAttribute), false);
+				if (attributes != null)
+				{
+					for (int i = 0; i < attributes.Length; ++i)
+					{
+						namespaceList.Add(((CustomSerializedXmlSchemaAttribute)attributes[i]).XmlNamespace);
+					}
+				}
+			}
+
+			foreach (ExtensionModelBinding extensionType in extensionTypes)
+			{
+				object[] attributes = extensionType.Type.GetCustomAttributes(typeof(CustomSerializedXmlSchemaAttribute), false);
+				if (attributes != null)
+				{
+					for (int i = 0; i < attributes.Length; ++i)
+					{
+						namespaceList.Add(((CustomSerializedXmlSchemaAttribute)attributes[i]).XmlNamespace);
+					}
+				}
+			}
+
+#pragma warning disable CS0618
+			// UNDONE: Remove CustomSerializedXmlNamespacesAttribute support
+			List<CustomSerializedXmlNamespacesAttribute> namespaceAttributes = new List<CustomSerializedXmlNamespacesAttribute>();
 			foreach (Type standardType in standardTypes)
 			{
 				object[] attributes = standardType.GetCustomAttributes(typeof(CustomSerializedXmlNamespacesAttribute), false);
 				CustomSerializedXmlNamespacesAttribute currentAttribute;
-				int currentNamespaceCount;
 				if (attributes != null &&
 					attributes.Length != 0 &&
-					0 != (currentNamespaceCount = (currentAttribute = (CustomSerializedXmlNamespacesAttribute)attributes[0]).Count))
+					0 != (currentAttribute = (CustomSerializedXmlNamespacesAttribute)attributes[0]).Count)
 				{
-					totalNamespaceCount += currentNamespaceCount;
-					namespaceAttributes[serializedAttributeCount] = currentAttribute;
-					++serializedAttributeCount;
+					namespaceAttributes.Add(currentAttribute);
 				}
 			}
 			foreach (ExtensionModelBinding extensionType in extensionTypes)
 			{
 				object[] attributes = extensionType.Type.GetCustomAttributes(typeof(CustomSerializedXmlNamespacesAttribute), false);
 				CustomSerializedXmlNamespacesAttribute currentAttribute;
-				int currentNamespaceCount;
 				if (attributes != null &&
 					attributes.Length != 0 &&
-					0 != (currentNamespaceCount = (currentAttribute = (CustomSerializedXmlNamespacesAttribute)attributes[0]).Count))
+					0 != (currentAttribute = (CustomSerializedXmlNamespacesAttribute)attributes[0]).Count)
 				{
-					totalNamespaceCount += currentNamespaceCount;
-					namespaceAttributes[serializedAttributeCount] = currentAttribute;
-					++serializedAttributeCount;
+					namespaceAttributes.Add(currentAttribute);
 				}
 			}
-			string[] namespaces = new string[totalNamespaceCount];
-			int namespaceIndex = -1;
-			for (int i = 0; i < serializedAttributeCount; ++i)
+
+			for (int i = 0, count = namespaceAttributes.Count; i < count; ++i)
 			{
 				CustomSerializedXmlNamespacesAttribute currentAttribute = namespaceAttributes[i];
 				int attributeCount = currentAttribute.Count;
 				for (int j = 0; j < attributeCount; ++j)
 				{
-					namespaces[++namespaceIndex] = currentAttribute[j];
+					namespaceList.Add(currentAttribute[j]);
 				}
 			}
+#pragma warning restore CS0618
+
+			string[] namespaces = new string[namespaceList.Count];
+			namespaceList.CopyTo(namespaces);
 			Array.Sort<string>(namespaces);
 			if (unrecognizedNamespaces != null)
 			{

--- a/ORMModel/ObjectModel/ORMCore.SerializationExtensions.cs
+++ b/ORMModel/ObjectModel/ORMCore.SerializationExtensions.cs
@@ -25,7 +25,7 @@ using ORMSolutions.ORMArchitect.Framework.Shell;
 namespace ORMSolutions.ORMArchitect.Core.ObjectModel
 {
 	#region ORMCoreDomainModel model serialization
-	[CustomSerializedXmlNamespaces("http://schemas.neumont.edu/ORM/2006-04/ORMCore")]
+	[CustomSerializedXmlSchema("http://schemas.neumont.edu/ORM/2006-04/ORMCore", "ORM2Core.xsd")]
 	partial class ORMCoreDomainModel : ICustomSerializedDomainModel
 	{
 		/// <summary>The default XmlNamespace associated with the 'ORMCoreDomainModel' extension model</summary>

--- a/ORMModel/ObjectModel/ORMModel.resx
+++ b/ORMModel/ObjectModel/ORMModel.resx
@@ -255,6 +255,10 @@
 		<value>The registered extension type '{0}' has a missing or invalid extension load key and cannot be safely used in NORMA.</value>
 		<comment>Exception text used when a NORMA extension fails because of a missing or invalid load key.</comment>
 	</data>
+	<data name="LoadException.ExtensionSkippingNotSupportedByStore" xml:space="preserve">
+		<value>The Store being loaded does not support skipping non-generative extensions.</value>
+		<comment>Exception text used when a non-generative load is attempted on a store that does not support the ISkipExtensions interface.</comment>
+	</data>
 	<data name="LogicalCombinationOperator.And" xml:space="preserve">
 		<value>And</value>
 	</data>

--- a/ORMModel/ObjectModel/VerbalizationSnippetSetsManager.cs
+++ b/ORMModel/ObjectModel/VerbalizationSnippetSetsManager.cs
@@ -1161,7 +1161,13 @@ namespace ORMSolutions.ORMArchitect.Core.ObjectModel
 							{
 								retVal = myReaderSettings = new XmlReaderSettings();
 								retVal.ValidationType = ValidationType.Schema;
-								retVal.Schemas.Add(SchemaNamespace, new XmlTextReader(typeof(VerbalizationSnippetSetsManager).Assembly.GetManifestResourceStream(typeof(VerbalizationSnippetSetsManager), "VerbalizationUntypedSnippets.xsd")));
+								using (Stream stream = typeof(VerbalizationSnippetSetsManager).Assembly.GetManifestResourceStream(typeof(VerbalizationSnippetSetsManager), "VerbalizationUntypedSnippets.xsd"))
+								{
+									using (XmlReader reader = new XmlTextReader(stream))
+									{
+										retVal.Schemas.Add(SchemaNamespace, reader);
+									}
+								}
 								retVal.NameTable = Names;
 							}
 						}

--- a/ORMModel/Resources/ResourceStringsGenerator.cs
+++ b/ORMModel/Resources/ResourceStringsGenerator.cs
@@ -972,6 +972,14 @@ namespace ORMSolutions.ORMArchitect.Core
 				return ResourceStrings.GetString(ResourceManagers.Model, "LoadException.InvalidLoadKey");
 			}
 		}
+		/// <summary>Exception text used when a non-generative load is attempted on a store that does not support the ISkipExtensions interface.</summary>
+		public static string LoadExceptionExtensionSkippingNotSupportedByStore
+		{
+			get
+			{
+				return ResourceStrings.GetString(ResourceManagers.Model, "LoadException.ExtensionSkippingNotSupportedByStore");
+			}
+		}
 		/// <summary>Exception message when an attempt is made to parse invalid range text for a cardinality constraint.</summary>
 		public static string ModelExceptionCardinalityConstraintInvalidRangeText
 		{

--- a/ORMModel/Resources/ResourceStringsGenerator.xml
+++ b/ORMModel/Resources/ResourceStringsGenerator.xml
@@ -171,6 +171,7 @@
 	<ResourceString name="ModelBrowserWindowTitle" model="Diagram" resourceName="ORMModelBrowser.WindowTitle"/>
 	<ResourceString name="LoadExceptionIncompatibleAssembly" model="Model" resourceName="LoadException.IncompatibleAssembly"/>
 	<ResourceString name="LoadExceptionInvalidLoadKey" model="Model" resourceName="LoadException.InvalidLoadKey"/>
+	<ResourceString name="LoadExceptionExtensionSkippingNotSupportedByStore" model="Model" resourceName="LoadException.ExtensionSkippingNotSupportedByStore"/>
 	<ResourceString name="ModelExceptionCardinalityConstraintInvalidRangeText" model="Model" resourceName="ModelException.CardinalityConstraint.InvalidRangeText"/>
 	<ResourceString name="ModelExceptionUnaryRoleCardinalityConstraintUnaryOnly" model="Model" resourceName="ModelException.UnaryRoleCardinalityConstraint.UnaryOnly"/>
 	<ResourceString name="ModelExceptionModelErrorCategoryInvalid" model="Model" resourceName="ModelException.ModelErrorCategory.TypeNotDerivedFromModelErrorCategory"/>

--- a/ORMModel/ShapeModel/ORMShape.SerializationExtensions.cs
+++ b/ORMModel/ShapeModel/ORMShape.SerializationExtensions.cs
@@ -24,7 +24,7 @@ using ORMSolutions.ORMArchitect.Framework.Shell;
 namespace ORMSolutions.ORMArchitect.Core.ShapeModel
 {
 	#region ORMShapeDomainModel model serialization
-	[CustomSerializedXmlNamespaces("http://schemas.neumont.edu/ORM/2006-04/ORMDiagram")]
+	[CustomSerializedXmlSchema("http://schemas.neumont.edu/ORM/2006-04/ORMDiagram", "ORM2Diagram.xsd")]
 	partial class ORMShapeDomainModel : ICustomSerializedDomainModel
 	{
 		/// <summary>The default XmlNamespace associated with the 'ORMShapeDomainModel' extension model</summary>

--- a/ORMModel/Shell/ORMDesignerSettings.cs
+++ b/ORMModel/Shell/ORMDesignerSettings.cs
@@ -109,7 +109,13 @@ namespace ORMSolutions.ORMArchitect.Core.Shell
 							{
 								retVal = myReaderSettings = new XmlReaderSettings();
 								retVal.ValidationType = ValidationType.Schema;
-								retVal.Schemas.Add(SchemaNamespace, new XmlTextReader(typeof(ORMDesignerSettings).Assembly.GetManifestResourceStream(typeof(ORMDesignerSettings), "ORMDesignerSettings.xsd")));
+								using (Stream stream = typeof(ORMDesignerSettings).Assembly.GetManifestResourceStream(typeof(ORMDesignerSettings), "ORMDesignerSettings.xsd"))
+								{
+									using (XmlReader reader = new XmlTextReader(stream))
+									{
+										retVal.Schemas.Add(SchemaNamespace, reader);
+									}
+								}
 								retVal.NameTable = Names;
 							}
 						}

--- a/ORMModel/Transforms/SerializationExtensions.xslt
+++ b/ORMModel/Transforms/SerializationExtensions.xslt
@@ -2275,13 +2275,16 @@
 				<plx:pragma type="closeRegion" data="{$ModelName} model serialization"/>
 			</plx:trailingInfo>
 			<xsl:if test="$namespaces">
-				<plx:attribute dataTypeName="CustomSerializedXmlNamespaces">
-					<xsl:for-each select="$namespaces">
+				<xsl:for-each select="$namespaces">
+					<plx:attribute dataTypeName="CustomSerializedXmlSchema">
 						<plx:passParam>
 							<plx:string data="{@URI}"/>
 						</plx:passParam>
-					</xsl:for-each>
-				</plx:attribute>
+						<plx:passParam>
+							<plx:string data="{@SchemaFile}"/>
+						</plx:passParam>
+					</plx:attribute>
+				</xsl:for-each>
 			</xsl:if>
 			<plx:implementsInterface dataTypeName="ICustomSerializedDomainModel"/>
 			<plx:field name="XmlNamespace" visibility="public" static="true" readOnly="true" dataTypeName=".string">

--- a/Oial/ORMOialBridge/ORMOialBridge.SerializationExtensions.cs
+++ b/Oial/ORMOialBridge/ORMOialBridge.SerializationExtensions.cs
@@ -24,7 +24,7 @@ using ORMSolutions.ORMArchitect.Framework.Shell;
 namespace ORMSolutions.ORMArchitect.ORMToORMAbstractionBridge
 {
 	#region ORMToORMAbstractionBridgeDomainModel model serialization
-	[CustomSerializedXmlNamespaces("http://schemas.neumont.edu/ORM/Bridge/2007-06/ORMToORMAbstraction")]
+	[CustomSerializedXmlSchema("http://schemas.neumont.edu/ORM/Bridge/2007-06/ORMToORMAbstraction", "ORMToORMAbstraction.xsd")]
 	partial class ORMToORMAbstractionBridgeDomainModel : ICustomSerializedDomainModel
 	{
 		/// <summary>The default XmlNamespace associated with the 'ORMToORMAbstractionBridgeDomainModel' extension model</summary>

--- a/Oial/OialModel/OialModel.SerializationExtensions.cs
+++ b/Oial/OialModel/OialModel.SerializationExtensions.cs
@@ -24,7 +24,8 @@ using ORMSolutions.ORMArchitect.Framework.Shell;
 namespace ORMSolutions.ORMArchitect.ORMAbstraction
 {
 	#region AbstractionDomainModel model serialization
-	[CustomSerializedXmlNamespaces("http://schemas.neumont.edu/ORM/Abstraction/2007-06/Core", "http://schemas.neumont.edu/ORM/Abstraction/2007-06/DataTypes/Core")]
+	[CustomSerializedXmlSchema("http://schemas.neumont.edu/ORM/Abstraction/2007-06/Core", "ORMAbstraction.xsd")]
+	[CustomSerializedXmlSchema("http://schemas.neumont.edu/ORM/Abstraction/2007-06/DataTypes/Core", "ORMAbstractionDatatypes.xsd")]
 	partial class AbstractionDomainModel : ICustomSerializedDomainModel
 	{
 		/// <summary>The default XmlNamespace associated with the 'AbstractionDomainModel' extension model</summary>

--- a/RelationalModel/DcilModel/DcilModel.SerializationExtensions.cs
+++ b/RelationalModel/DcilModel/DcilModel.SerializationExtensions.cs
@@ -24,7 +24,8 @@ using ORMSolutions.ORMArchitect.Framework.Shell;
 namespace ORMSolutions.ORMArchitect.RelationalModels.ConceptualDatabase
 {
 	#region ConceptualDatabaseDomainModel model serialization
-	[CustomSerializedXmlNamespaces("http://schemas.neumont.edu/ORM/Relational/2007-06/ConceptualDatabase", "http://schemas.orm.net/DIL/DILDT")]
+	[CustomSerializedXmlSchema("http://schemas.neumont.edu/ORM/Relational/2007-06/ConceptualDatabase", "ConceptualDatabase.xsd")]
+	[CustomSerializedXmlSchema("http://schemas.orm.net/DIL/DILDT", "DILDT.xsd")]
 	partial class ConceptualDatabaseDomainModel : ICustomSerializedDomainModel
 	{
 		/// <summary>The default XmlNamespace associated with the 'ConceptualDatabaseDomainModel' extension model</summary>

--- a/RelationalModel/OialDcilBridge/OialDcilBridge.SerializationExtensions.cs
+++ b/RelationalModel/OialDcilBridge/OialDcilBridge.SerializationExtensions.cs
@@ -24,7 +24,7 @@ using ORMSolutions.ORMArchitect.Framework.Shell;
 namespace ORMSolutions.ORMArchitect.ORMAbstractionToConceptualDatabaseBridge
 {
 	#region ORMAbstractionToConceptualDatabaseBridgeDomainModel model serialization
-	[CustomSerializedXmlNamespaces("http://schemas.neumont.edu/ORM/Bridge/2007-06/ORMAbstractionToConceptualDatabase")]
+	[CustomSerializedXmlSchema("http://schemas.neumont.edu/ORM/Bridge/2007-06/ORMAbstractionToConceptualDatabase", "ORMAbstractionToConceptualDatabase.xsd")]
 	partial class ORMAbstractionToConceptualDatabaseBridgeDomainModel : ICustomSerializedDomainModel
 	{
 		/// <summary>The default XmlNamespace associated with the 'ORMAbstractionToConceptualDatabaseBridgeDomainModel' extension model</summary>

--- a/Tools/ORMCustomTool/IORMGenerator.cs
+++ b/Tools/ORMCustomTool/IORMGenerator.cs
@@ -20,6 +20,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.IO;
+using ORMSolutions.ORMArchitect.Framework;
 #if VISUALSTUDIO_10_0
 using Microsoft.Build.Construction;
 using BuildItem = Microsoft.Build.Construction.ProjectItemElement;
@@ -30,6 +31,16 @@ using Microsoft.Build.BuildEngine;
 
 namespace ORMSolutions.ORMArchitect.ORMCustomTool
 {
+	/// <summary>
+	/// Used by <see cref="IORMGenerator.GenerateOutput"/> to retrieve a Stream for
+	/// a format identifier. Adding this abstraction instead of a direct callback
+	/// insulates the complications of integrating the generator with multiple outputs
+	/// of the same format.
+	/// </summary>
+	/// <param name="formatName"></param>
+	/// <returns></returns>
+	public delegate Stream GetFormatStream(string formatName);
+
 	/// <summary>
 	/// Implementations of this interface generate a specific output format based on requested input formats.
 	/// </summary>
@@ -115,6 +126,33 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 		}
 
 		/// <summary>
+		/// A list of a generator types recognized by this generator. Specifying generator
+		/// types allows multiple different files of the same type to be generated from a single
+		/// model.
+		/// </summary>
+		IList<string> GeneratorTargetTypes
+		{
+			get;
+		}
+
+		/// <summary>
+		/// A list of a generator instructions matching <see cref="GeneratorTargetTypes"/>. If
+		/// the generator targets sent to a generator have placeholders then the instructions
+		/// for the generator types defined by this generator will be placed in the parameters
+		/// instead of empty data.
+		/// </summary>
+		/// <remarks>The registry format for this is GeneratorTargetInstruction_TARGETTYPE where TARGETTYPE is one
+		/// of the values in the GeneratorTargetTypes list. If input generators also have generator targets then
+		/// this will be listed. Note that the generator targets passed to a transform my also include target types
+		/// not directly defined with this generator. These items may be in the placeholders parameter, which
+		/// is a list of parameter names (in the _GeneratorPlaceholders parameter) that are empty because they
+		/// are placeholders.</remarks>
+		IList<string> GeneratorTargetInstructions
+		{
+			get;
+		}
+
+		/// <summary>
 		/// If <see cref="ProvidesOutputFormat"/> is part of the set of
 		/// <see cref="RequiresInputFormats"/> then this generator is used
 		/// to modify a previously generated instance of the same format.
@@ -170,9 +208,14 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 		/// </summary>
 		/// <param name="itemElement">The <see cref="ProjectItemElement"/> for which output is to be generated.</param>
 		/// <param name="outputStream">The <see cref="Stream"/> to which output is to be generated.</param>
-		/// <param name="inputFormatStreams">A read-only <see cref="IDictionary{String,Stream}"/> containing pairs of official output format names and read-only <see cref="Stream"/>s containing the output in that format.</param>
+		/// <param name="inputFormatStreams">A read-only <see cref="GetFormatStream"/> callback returning a read-only
+		/// <see cref="Stream"/>s containing the output of that format.</param>
 		/// <param name="defaultNamespace">A <see cref="String"/> containing the default namespace that should be used in the generated output, as appropriate.</param>
 		/// <param name="itemProperties">An implementation of <see cref="IORMGeneratorItemProperties"/> to allow retrieval of additional properties</param>
+		/// <param name="targetInstance">Generator target instances distinguish this generated output from other instances of the same format. The target types are
+		/// treated as parameter names and the ids as parameter values. Target types should not overlap input or reference format names. Note that target instances
+		/// may be specified even if a format does not directly support target types because input formats may also be parameterized and the inputs target instances
+		/// are also provided as parameters.</param>
 		/// <remarks>
 		/// <para><paramref name="inputFormatStreams"/> is guaranteed to contain the output <see cref="Stream"/>s for
 		/// the "ORM" format and any formats returned by this <see cref="IORMGenerator"/>'s implementation of
@@ -185,7 +228,7 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 		/// ...
 		/// oialStream.Seek(0, SeekOrigin.Begin);</example></para>
 		/// </remarks>
-		void GenerateOutput(ProjectItemElement itemElement, Stream outputStream, IDictionary<string, Stream> inputFormatStreams, string defaultNamespace, IORMGeneratorItemProperties itemProperties);
+		void GenerateOutput(ProjectItemElement itemElement, Stream outputStream, GetFormatStream inputFormatStreams, string defaultNamespace, IORMGeneratorItemProperties itemProperties, GeneratorTarget[] targetInstance);
 #else // VISUALSTUDIO_10_0
 		/// <summary>
 		/// Adds a <see cref="BuildItem"/> for the generated file to <paramref name="buildItemGroup"/>.

--- a/Tools/ORMCustomTool/IORMGenerator.cs
+++ b/Tools/ORMCustomTool/IORMGenerator.cs
@@ -249,9 +249,14 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 		/// </summary>
 		/// <param name="buildItem">The <see cref="BuildItem"/> for which output is to be generated.</param>
 		/// <param name="outputStream">The <see cref="Stream"/> to which output is to be generated.</param>
-		/// <param name="inputFormatStreams">A read-only <see cref="IDictionary{String,Stream}"/> containing pairs of official output format names and read-only <see cref="Stream"/>s containing the output in that format.</param>
+		/// <param name="inputFormatStreams">A read-only <see cref="GetFormatStream"/> callback returning a read-only
+		/// <see cref="Stream"/>s containing the output of that format.</param>
 		/// <param name="defaultNamespace">A <see cref="String"/> containing the default namespace that should be used in the generated output, as appropriate.</param>
 		/// <param name="itemProperties">An implementation of <see cref="IORMGeneratorItemProperties"/> to allow retrieval of additional properties</param>
+		/// <param name="targetInstance">Generator target instances distinguish this generated output from other instances of the same format. The target types are
+		/// treated as parameter names and the ids as parameter values. Target types should not overlap input or reference format names. Note that target instances
+		/// may be specified even if a format does not directly support target types because input formats may also be parameterized and the inputs target instances
+		/// are also provided as parameters.</param>
 		/// <remarks>
 		/// <para><paramref name="inputFormatStreams"/> is guaranteed to contain the output <see cref="Stream"/>s for
 		/// the "ORM" format and any formats returned by this <see cref="IORMGenerator"/>'s implementation of
@@ -264,7 +269,7 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 		/// ...
 		/// oialStream.Seek(0, SeekOrigin.Begin);</example></para>
 		/// </remarks>
-		void GenerateOutput(BuildItem buildItem, Stream outputStream, IDictionary<string, Stream> inputFormatStreams, string defaultNamespace, IORMGeneratorItemProperties itemProperties);
+		void GenerateOutput(BuildItem buildItem, Stream outputStream, GetFormatStream inputFormatStreams, string defaultNamespace, IORMGeneratorItemProperties itemProperties, GeneratorTarget[] targetInstance);
 #endif // VISUALSTUDIO_10_0
 	}
 	/// <summary>

--- a/Tools/ORMCustomTool/Install.bat
+++ b/Tools/ORMCustomTool/Install.bat
@@ -15,12 +15,13 @@ CALL:_CleanupFile "%NORMABinDir%\ORMSolutions.ORMArchitect.ORMCustomTool.xml"
 IF EXIST "%NORMABinDir%\ORMSolutions.ORMArchitect.ORMCustomTool.dll" (REN "%NORMABinDir%\ORMSolutions.ORMArchitect.ORMCustomTool.dll" "ORMSolutions.ORMArchitect.ORMCustomTool.dll.delete.%RANDOM%")
 
 :: Install Custom Tool DLL
-IF "%VSSideBySide%"=="" (
 SET TargetBaseName=ORMSolutions.ORMArchitect.ORMCustomTool.%TargetVisualStudioShortProductName%
 DEL /F /Q "%NORMABinDir%\%TargetBaseName%.dll.delete.*" 1>NUL 2>&1
 IF EXIST "%NORMABinDir%\%TargetBaseName%.dll" (REN "%NORMABinDir%\%TargetBaseName%.dll" "%TargetBaseName%.dll.delete.%RANDOM%")
 XCOPY /Y /D /V /Q "%RootDir%\%BuildOutDir%\%TargetBaseName%.dll" "%NORMABinDir%\"
 XCOPY /Y /D /V /Q "%RootDir%\%BuildOutDir%\%TargetBaseName%.pdb" "%NORMABinDir%\"
+
+IF "%VSSideBySide%"=="" (
 :: For some reason, the next copy is randomly giving errors about half the time. They can be safely ignored, so they've been redirected to NUL.
 XCOPY /Y /D /V /Q "%RootDir%\%BuildOutDir%\%TargetBaseName%.xml" "%NORMABinDir%\" 2>NUL
 CALL:_InstallCustomToolReg "%VSRegistryRootVersion%"
@@ -212,6 +213,15 @@ SHIFT /8
 IF NOT "%~9"=="" (REG ADD "%NORMAGenerators%\%~1" /f /v "ReferenceInputFormats" /t REG_MULTI_SZ /d "%~9") 1>NUL
 SHIFT /8
 IF NOT "%~9"=="" (REG ADD "%NORMAGenerators%\%~1" /f /v "CompanionOutputFormats" /t REG_MULTI_SZ /d "%~9") 1>NUL
+SHIFT /8
+IF NOT "%~9"=="" (REG ADD "%NORMAGenerators%\%~1" /f /v "GeneratorTargetTypes" /t REG_MULTI_SZ /d "%~9") 1>NUL
+:_NextInstruction
+SHIFT /8
+IF "%~9"=="" GOTO:EOF
+SET InstructionType=%~9
+SHIFT /8
+REG ADD "%NORMAGenerators%\%~1" /f /v "GeneratorTargetInstruction_%InstructionType%" /d "%~9") 1>NUL
+GOTO:_NextInstruction
 GOTO:EOF
 
 :_CleanupFile

--- a/Tools/ORMCustomTool/ORMCustomTool.cs
+++ b/Tools/ORMCustomTool/ORMCustomTool.cs
@@ -23,6 +23,7 @@ using System.Collections.ObjectModel;
 using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Runtime.Serialization.Formatters.Binary;
 using System.Text;
 using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Shell;
@@ -33,12 +34,15 @@ using VSLangProj;
 
 using Debug = System.Diagnostics.Debug;
 using IServiceProvider = System.IServiceProvider;
-using DebuggerStepThroughAttribute = System.Diagnostics.DebuggerStepThroughAttribute;
 using VSConstants = Microsoft.VisualStudio.VSConstants;
 using ErrorHandler = Microsoft.VisualStudio.ErrorHandler;
 using IOleServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
 using IVsTextLines = Microsoft.VisualStudio.TextManager.Interop.IVsTextLines;
 using IVsTextView = Microsoft.VisualStudio.TextManager.Interop.IVsTextView;
+using ORMSolutions.ORMArchitect.Framework;
+using ORMSolutions.ORMArchitect.Core.Load;
+using ORMSolutions.ORMArchitect.Core.Shell;
+using Microsoft.VisualStudio.Modeling;
 #if VISUALSTUDIO_10_0
 using Microsoft.Build.Construction;
 #else
@@ -84,8 +88,8 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 		private const string ITEMGROUP_CONDITIONEND = "')";
 		private const string DEBUG_ERROR_CATEGORY = "ORMCustomTool";
 		private const string ORM_OUTPUT_FORMAT = "ORM";
-#endregion // Private Constants
-#region Member Variables
+		#endregion // Private Constants
+		#region Member Variables
 		/// <summary>
 		/// A wrapper object to provide unified managed and unmanaged IServiceProvider implementations
 		/// </summary>
@@ -100,8 +104,8 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 		/// </summary>
 		private IOleServiceProvider _dteServiceProvider;
 		private CodeDomProvider _codeDomProvider;
-#endregion // Member Variables
-#region Constructors
+		#endregion // Member Variables
+		#region Constructors
 		/// <summary>
 		/// Instantiates a new instance of <see cref="ORMCustomTool"/>.
 		/// </summary>
@@ -111,8 +115,8 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 			// unless SetSite has been called on us.
 			this._serviceProvider = new ServiceProvider(this, true);
 		}
-#endregion // Constructors
-#region Private Helper Methods
+		#endregion // Constructors
+		#region Private Helper Methods
 		private static void ReportError(string message, Exception ex)
 		{
 			ReportError(message, DEBUG_ERROR_CATEGORY, ex);
@@ -130,10 +134,11 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 		/// </summary>
 		public static ProjectItemGroupElement GetItemGroup(ProjectRootElement rootElement, string projectItemName)
 		{
+			string matchCondition = string.Concat(ITEMGROUP_CONDITIONSTART, projectItemName, ITEMGROUP_CONDITIONEND);
 			foreach (ProjectItemGroupElement itemGroup in rootElement.ItemGroups)
 			{
 				// We don't want to process BuildItemGroups that are from outside this project
-				if (String.Equals(itemGroup.Condition.Trim(), string.Concat(ITEMGROUP_CONDITIONSTART, projectItemName, ITEMGROUP_CONDITIONEND), StringComparison.OrdinalIgnoreCase))
+				if (string.Equals(itemGroup.Condition.Trim(), matchCondition, StringComparison.OrdinalIgnoreCase))
 				{
 					return itemGroup;
 				}
@@ -146,10 +151,11 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 		/// </summary>
 		public static BuildItemGroup GetItemGroup(Project project, string projectItemName)
 		{
+			string matchCondition = string.Concat(ITEMGROUP_CONDITIONSTART, projectItemName, ITEMGROUP_CONDITIONEND);
 			foreach (BuildItemGroup buildItemGroup in project.ItemGroups)
 			{
 				// We don't want to process BuildItemGroups that are from outside this project
-				if (!buildItemGroup.IsImported && String.Equals(buildItemGroup.Condition.Trim(), string.Concat(ITEMGROUP_CONDITIONSTART, projectItemName, ITEMGROUP_CONDITIONEND), StringComparison.OrdinalIgnoreCase))
+				if (!buildItemGroup.IsImported && string.Equals(buildItemGroup.Condition.Trim(), matchCondition, StringComparison.OrdinalIgnoreCase))
 				{
 					return buildItemGroup;
 				}
@@ -260,8 +266,8 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 				return retVal;
 			}
 		}
-#endregion // Private Helper Methods
-#region ServiceProvider Interface Implementations
+		#endregion // Private Helper Methods
+		#region ServiceProvider Interface Implementations
 		/// <summary>
 		/// Returns a service instance of type <typeparamref name="T"/>, or <see langword="null"/> if no service instance of
 		/// type <typeparamref name="T"/> is available.
@@ -271,7 +277,7 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 		{
 			return this._serviceProvider.GetService(typeof(T)) as T;
 		}
-#region IObjectWithSite Members
+		#region IObjectWithSite Members
 		void IObjectWithSite.GetSite(ref Guid riid, out IntPtr ppvSite)
 		{
 			(_serviceProvider as IObjectWithSite).GetSite(ref riid, out ppvSite);
@@ -283,8 +289,8 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 			_dteServiceProvider = null;
 			_codeDomProvider = null;
 		}
-#endregion // IObjectWithSite Members
-#region IOleServiceProvider Members
+		#endregion // IObjectWithSite Members
+		#region IOleServiceProvider Members
 		int IOleServiceProvider.QueryService(ref Guid guidService, ref Guid riid, out IntPtr ppvObject)
 		{
 			IOleServiceProvider customToolServiceProvider = this._customToolServiceProvider;
@@ -321,16 +327,16 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 			}
 			return errorCode;
 		}
-#endregion // IOleServiceProvider Members
-#region IServiceProvider Members
+		#endregion // IOleServiceProvider Members
+		#region IServiceProvider Members
 		object IServiceProvider.GetService(Type serviceType)
 		{
 			// Pass this on to our ServiceProvider which will pass it back to us via our implementation of IOleServiceProvider
 			return this._serviceProvider.GetService(serviceType);
 		}
-#endregion // IServiceProvider Members
-#endregion // ServiceProvider Interface Implementations
-#region IVsSingleFileGenerator Members
+		#endregion // IServiceProvider Members
+		#endregion // ServiceProvider Interface Implementations
+		#region IVsSingleFileGenerator Members
 		/// <summary>
 		/// The types of reports to write during generation
 		/// </summary>
@@ -364,28 +370,28 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 		}
 		int IVsSingleFileGenerator.Generate(string wszInputFilePath, string bstrInputFileContents, string wszDefaultNamespace, IntPtr[] rgbOutputFileContents, out uint pcbOutput, IVsGeneratorProgress pGenerateProgress)
 		{
-#region ParameterValidation
-			if (String.IsNullOrEmpty(bstrInputFileContents))
+			#region ParameterValidation
+			if (string.IsNullOrEmpty(bstrInputFileContents))
 			{
-				if (!String.IsNullOrEmpty(wszInputFilePath))
+				if (!string.IsNullOrEmpty(wszInputFilePath))
 				{
 					bstrInputFileContents = File.ReadAllText(wszInputFilePath);
 				}
-				if (String.IsNullOrEmpty(bstrInputFileContents))
+				if (string.IsNullOrEmpty(bstrInputFileContents))
 				{
 					rgbOutputFileContents[0] = IntPtr.Zero;
 					pcbOutput = 0;
 					return VSConstants.E_INVALIDARG;
 				}
 			}
-#endregion
+			#endregion
 			StringWriter outputWriter = new StringWriter();
 			CodeDomProvider codeProvider = CodeDomProvider;
 			GenerateCode(
 				bstrInputFileContents,
 				wszDefaultNamespace,
 				pGenerateProgress,
-#region Report callback
+				#region Report callback
 				delegate(string message, ReportType type, Exception ex)
 				{
 					switch (type)
@@ -462,7 +468,7 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 							break;
 					}
 				}
-#endregion // Report callback
+				#endregion // Report callback
 			);
 			outputWriter.Flush();
 			byte[] bytes = Encoding.UTF8.GetBytes(outputWriter.ToString());
@@ -477,7 +483,7 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 		}
 		private sealed class ItemPropertiesImpl : IORMGeneratorItemProperties
 		{
-#region Member Variables and Constructor
+			#region Member Variables and Constructor
 			private EnvDTE.Properties myProjectProperties;
 			private EnvDTE.Properties myProjectItemProperties;
 			private References myReferences;
@@ -491,8 +497,8 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 				myProjectProperties = project.Properties;
 				myProjectItemProperties = projectItem.Properties;
 			}
-#endregion // Member Variables and Constructor
-#region IORMGeneratorItemProperties Members
+			#endregion // Member Variables and Constructor
+			#region IORMGeneratorItemProperties Members
 			/// <summary>
 			/// Implements <see cref="IORMGeneratorItemProperties.GetItemProperty"/>
 			/// </summary>
@@ -543,7 +549,7 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 				}
 				return retVal;
 			}
-#endregion // IORMGeneratorItemProperties Members
+			#endregion // IORMGeneratorItemProperties Members
 		}
 		/// <summary>
 		/// Helper structure for GenerateCode to
@@ -561,11 +567,58 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 				BuildItem item,
 #endif
 				IORMGenerator generator,
+				GeneratorTarget[] targetInstance,
 				int step)
 			{
 				BuildItem = item;
 				ORMGenerator = generator;
+				TargetInstance = targetInstance;
 				FormatStep = step;
+				Signature = BuildSignature(generator.ProvidesOutputFormat, targetInstance);
+			}
+			/// <summary>
+			/// Generator a string signature for the given format and target instances
+			/// </summary>
+			public static string BuildSignature(string generatedFormat, GeneratorTarget[] targetInstance, IList<int> filterIndices = null)
+			{
+				int instanceLength;
+				if (targetInstance == null ||
+					(instanceLength = targetInstance.Length) == 0 ||
+					(filterIndices != null && (filterIndices.Count > instanceLength || (filterIndices[filterIndices.Count - 1] > (instanceLength - 1)))))
+				{
+					return generatedFormat;
+				}
+
+				// Signature is the generator name followed by alternating target type/target value
+				// pairs. Delimiter is character 1. Note that GeneratorTarget ids are not guaranteed
+				// to be unique and are used only for the generator transform.
+				string[] names;
+				if (filterIndices == null)
+				{
+					names = new string[instanceLength + instanceLength + 1];
+					names[0] = generatedFormat;
+					int iNext = 0;
+					for (int i = 0; i < instanceLength; ++i)
+					{
+						GeneratorTarget target = targetInstance[i];
+						names[++iNext] = target.TargetType;
+						names[++iNext] = target.TargetName ?? string.Empty;
+					}
+				}
+				else
+				{
+					instanceLength = filterIndices.Count;
+					names = new string[instanceLength + instanceLength + 1];
+					names[0] = generatedFormat;
+					int iNext = 0;
+					for (int i = 0; i < instanceLength; ++i)
+					{
+						GeneratorTarget target = targetInstance[filterIndices[i]];
+						names[++iNext] = target.TargetType;
+						names[++iNext] = target.TargetName ?? string.Empty;
+					}
+				}
+				return string.Join(new string((char)1, 1), names);
 			}
 			/// <summary>
 			/// Does the provided format step represent the
@@ -592,18 +645,18 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 			/// The <see cref="ProjectItemElement"/> that corresponds to
 			/// the generated file.
 			/// </summary>
-			public ProjectItemElement BuildItem;
+			public readonly ProjectItemElement BuildItem;
 #else // VISUALSTUDIO_10_0
 			/// <summary>
 			/// The <see cref="Microsoft.Build.BuildEngine.BuildItem"/> that corresponds to
 			/// the generated file.
 			/// </summary>
-			public BuildItem BuildItem;
+			public readonly BuildItem BuildItem;
 #endif // VISUALSTUDIO_10_0
 			/// <summary>
 			/// The <see cref="IORMGenerator"/> used to generate this step
 			/// </summary>
-			public IORMGenerator ORMGenerator;
+			public readonly IORMGenerator ORMGenerator;
 			/// <summary>
 			/// The format step. This is a lightly encoded number, with
 			/// a bitwise-inverse negative number indicating the final step.
@@ -613,7 +666,15 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 			/// with a none-final step should only be sent to the next
 			/// step in the sequence.
 			/// </summary>
-			public int FormatStep;
+			public readonly int FormatStep;
+			/// <summary>
+			/// Ordered generator targets specified with this build item.
+			/// </summary>
+			public readonly GeneratorTarget[] TargetInstance;
+			/// <summary>
+			/// A combination of the generator name and generator target names in string form
+			/// </summary>
+			public readonly string Signature;
 		}
 		private void GenerateCode(string bstrInputFileContents, string wszDefaultNamespace, IVsGeneratorProgress pGenerateProgress, WriteReportItem report)
 		{
@@ -630,13 +691,13 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 
 			// If we weren't passed a default namespace, pick one up from the project properties
 			EnvDTE.Project envProject = projectItem.ContainingProject;
-			if (String.IsNullOrEmpty(wszDefaultNamespace))
+			if (string.IsNullOrEmpty(wszDefaultNamespace))
 			{
 				wszDefaultNamespace = envProject.Properties.Item("DefaultNamespace").Value as string;
 			}
 
 			string projectItemExtension = Path.GetExtension(projectItemName);
-			if (!String.Equals(projectItemExtension, EXTENSION_ORM, StringComparison.OrdinalIgnoreCase) && !String.Equals(projectItemExtension, EXTENSION_XML, StringComparison.OrdinalIgnoreCase))
+			if (!string.Equals(projectItemExtension, EXTENSION_ORM, StringComparison.OrdinalIgnoreCase) && !string.Equals(projectItemExtension, EXTENSION_XML, StringComparison.OrdinalIgnoreCase))
 			{
 				// UNDONE: Localize message.
 				report(
@@ -677,26 +738,44 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 			{
 				IORMGeneratorItemProperties itemProperties = new ItemPropertiesImpl(envProject, projectItem);
 				List<BoundBuildItem> boundBuildItems = new List<BoundBuildItem>(ormItemGroup.Count);
+				bool usingGeneratorTargets = false;
+				bool retrievedGeneratorTargets = false;
 				IDictionary<string, IORMGenerator> generators =
 #if VISUALSTUDIO_15_0
 					ORMCustomTool.GetORMGenerators(_serviceProvider);
 #else
 					ORMCustomTool.ORMGenerators;
 #endif
+				Action<
 #if VISUALSTUDIO_10_0
-				foreach (ProjectItemElement buildItem in ormItemGroup.Items)
+					ProjectItemElement,
 #else
-				foreach (BuildItem buildItem in ormItemGroup)
+					BuildItem
 #endif
+					Action<BoundBuildItem>,
+					Action<IORMGenerator, bool>> bindBuildItem = delegate (
+#if VISUALSTUDIO_10_0
+					ProjectItemElement buildItem,
+#else
+					BuildItem buildItem,
+#endif
+					Action<BoundBuildItem> onItemBound,
+					Action< IORMGenerator, bool> onGeneratorResolved)
 				{
-					string generatorNameData = buildItem.GetEvaluatedMetadata(ITEMMETADATA_ORMGENERATOR);
+					string generatorNameData;
 					string[] generatorNames;
 					int generatorNameCount;
-					if (!String.IsNullOrEmpty(generatorNameData) &&
-						String.Equals(buildItem.GetEvaluatedMetadata(ITEMMETADATA_DEPENDENTUPON), projectItemName, StringComparison.OrdinalIgnoreCase) &&
+					if (!string.IsNullOrEmpty(generatorNameData = buildItem.GetEvaluatedMetadata(ITEMMETADATA_ORMGENERATOR)) &&
+						!string.IsNullOrEmpty(generatorNameData = generatorNameData.Trim()) &&
+						string.Equals(buildItem.GetEvaluatedMetadata(ITEMMETADATA_DEPENDENTUPON), projectItemName, StringComparison.OrdinalIgnoreCase) &&
 						null != (generatorNames = generatorNameData.Split((char[])null, StringSplitOptions.RemoveEmptyEntries)) &&
 						0 != (generatorNameCount = generatorNames.Length))
 					{
+						// Always calculate the build item generator targets. If these do no end up matching a resolved GeneratorTarget instance
+						// when we report an error message and leave any existing file intact. However, we do not want to reprocess these
+						// items as if there was no generator target specified, so we want this information regardless of whether or not
+						// it binds to a resolved generator target instance.
+						GeneratorTarget[] buildItemGeneratorTargets = ORMCustomToolUtility.GeneratorTargetsFromBuildItem(buildItem);
 						IORMGenerator resolvedGenerator = null;
 						int resolvedGeneratorIndex = 0;
 						for (int i = 0; i < generatorNameCount; ++i)
@@ -705,10 +784,13 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 							string generatorName = generatorNames[i];
 							if (generators.TryGetValue(generatorName, out generator))
 							{
+								if (onGeneratorResolved != null)
+								{
+									onGeneratorResolved(generator, i == 0);
+								}
 								if (resolvedGenerator != null)
 								{
-									boundBuildItems.Add(new BoundBuildItem(buildItem, resolvedGenerator, resolvedGeneratorIndex));
-									resolvedGenerator = null;
+									onItemBound(new BoundBuildItem(buildItem, resolvedGenerator, buildItemGeneratorTargets, resolvedGeneratorIndex));
 									++resolvedGeneratorIndex;
 								}
 								resolvedGenerator = generator;
@@ -734,9 +816,36 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 						}
 						if (resolvedGenerator != null)
 						{
-							boundBuildItems.Add(new BoundBuildItem(buildItem, resolvedGenerator, ~resolvedGeneratorIndex));
+							onItemBound(new BoundBuildItem(buildItem, resolvedGenerator, buildItemGeneratorTargets, ~resolvedGeneratorIndex));
 						}
 					}
+				};
+
+				Dictionary<string, string> generatorNamesByOutputFormat = new Dictionary<string, string>();
+#if VISUALSTUDIO_10_0
+				foreach (ProjectItemElement buildItem in ormItemGroup.Items)
+#else
+				foreach (BuildItem buildItem in ormItemGroup)
+#endif
+				{
+					bindBuildItem(
+						buildItem,
+						delegate (BoundBuildItem boundItem)
+						{
+							boundBuildItems.Add(boundItem);
+						},
+						delegate(IORMGenerator resolvedGenerator, bool isFirst)
+						{
+							if (!usingGeneratorTargets)
+							{
+								usingGeneratorTargets = resolvedGenerator.GeneratorTargetTypes != null && resolvedGenerator.GeneratorTargetTypes.Count != 0;
+							}
+
+							if (isFirst && !generatorNamesByOutputFormat.ContainsKey(resolvedGenerator.ProvidesOutputFormat))
+							{
+								generatorNamesByOutputFormat[resolvedGenerator.ProvidesOutputFormat] = resolvedGenerator.OfficialName;
+							}
+						});
 				}
 				pGenerateProgress.Progress(1, 5);
 
@@ -748,6 +857,7 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 				Stream ormStream = null;
 				EnvDTE.Document projectItemDocument = projectItem.Document;
 				string itemPath;
+				IDictionary<string, GeneratorTarget[]> docTargets = null;
 				if (projectItemDocument != null)
 				{
 					if (null == (ormStream = ORMCustomToolUtility.GetDocumentExtension<Stream>(projectItemDocument, "ORMXmlStream", itemPath = projectItem.get_FileNames(0), _serviceProvider)))
@@ -758,7 +868,22 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 							ormStream = new MemoryStream(Encoding.UTF8.GetBytes(projectItemTextDocument.StartPoint.CreateEditPoint().GetText(projectItemTextDocument.EndPoint)), false);
 						}
 					}
+					else if (usingGeneratorTargets && !retrievedGeneratorTargets)
+					{
+						// If ORMXmlStream worked then so will ORMGeneratorTargets. If it returns null then there are no targets
+						// available, not because the request failed. Do not try again.
+						retrievedGeneratorTargets = false;
+						using (Stream targetsStream = ORMCustomToolUtility.GetDocumentExtension<Stream>(projectItemDocument, "ORMGeneratorTargets", itemPath, _serviceProvider))
+						{
+							if (targetsStream != null)
+							{
+								targetsStream.Seek(0, SeekOrigin.Begin);
+								ORMCustomToolUtility.NormalizeGeneratorTargets(docTargets = new BinaryFormatter().Deserialize(targetsStream) as IDictionary<string, GeneratorTarget[]>);
+							}
+						}
+					}
 				}
+
 				if (ormStream == null)
 				{
 					ormStream = new MemoryStream(Encoding.UTF8.GetBytes(bstrInputFileContents), false);
@@ -767,7 +892,60 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 				// Switch the ormStream to a readonly stream so we can reuse it multiple times
 				ormStream = new ReadOnlyStream(ormStream);
 
-				// Add the input ORM file Stream...
+				if (usingGeneratorTargets && !retrievedGeneratorTargets)
+				{
+					IVsShell shell;
+					if (null != (shell = _serviceProvider.GetService(typeof(SVsShell)) as IVsShell))
+					{
+						Guid pkgId = typeof(ORMDesignerPackage).GUID;
+						IVsPackage package;
+						if (0 != shell.IsPackageLoaded(ref pkgId, out package) || package == null)
+						{
+							shell.LoadPackage(ref pkgId, out package);
+						}
+
+						// Temporarily load the document so that the generator targets can be resolved.
+						// to extension manager load verification.
+						using (Store store = new ModelLoader(ORMDesignerPackage.ExtensionLoader, true).Load(ormStream))
+						{
+							ORMCustomToolUtility.NormalizeGeneratorTargets(docTargets = GeneratorTarget.ConsolidateGeneratorTargets(store as IFrameworkServices));
+						}
+						ormStream.Seek(0, SeekOrigin.Begin);
+					}
+				}
+
+				IDictionary<string, ORMCustomToolUtility.GeneratorTargetSet> targetSetsByFormatName = null;
+				Dictionary<string, int> generatorTargetsBySignature = null; // The value is an index into the instances in targetSetsByFormatName.
+				Dictionary<string, BitTracker> processedGeneratorTargets = null; // Each BitTracker has a count corresponding to the instance array in targetSetsByFormatName with the same key
+				if (usingGeneratorTargets)
+				{
+					targetSetsByFormatName = ORMCustomToolUtility.ExpandGeneratorTargets(generatorNamesByOutputFormat, docTargets
+#if VISUALSTUDIO_15_0
+						, _serviceProvider
+#endif // VISUALSTUDIO_15_0
+						);
+
+					if (targetSetsByFormatName != null)
+					{
+						generatorTargetsBySignature = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+						processedGeneratorTargets = new Dictionary<string, BitTracker>();
+						foreach (KeyValuePair<string, ORMCustomToolUtility.GeneratorTargetSet> kvp in targetSetsByFormatName)
+						{
+							string generatedFormat = kvp.Key;
+							GeneratorTarget[][] instances = kvp.Value.Instances;
+							processedGeneratorTargets[generatedFormat] = new BitTracker(instances.Length);
+							for (int i = 0; i < instances.Length; ++i)
+							{
+								generatorTargetsBySignature[BoundBuildItem.BuildSignature(generatedFormat, instances[i])] = i;
+							}
+						}
+					}
+				}
+
+				// Add the input ORM file Stream. To support multiple outputs of the same format
+				// these dictionaries are actually keyed by the BoundBuildItem.Signature, not just the
+				// format. However, genertor targets always apply to downstream formats, not the
+				// starting ORM file, so the format name is sufficient here.
 				outputFormatStreams.Add(ORM_OUTPUT_FORMAT, ormStream);
 				lastFormatSteps.Add(ORM_OUTPUT_FORMAT, -1);
 
@@ -783,242 +961,592 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 				pGenerateProgress.Progress(++progressCurrent, progressTotal);
 
 				// Execute the rest of the generators.
-				// We limit this to 100 iterations in order to avoid an infinite loop if no BuiltItem exists that provides
-				// the format required by one of the BuildItems that do exist.
-				string projectDirectory = null;
+				string projectDirectory = Path.GetDirectoryName(projectPath);
+				string newItemDirectory = Path.GetDirectoryName(projectItemRelPath);
+				EnvDTE.ProjectItems projectItems = projectItem.ProjectItems;
+				string sourceFileName = projectItem.Name;
+				Dictionary<string, string> sideEffectItemNames = null; // See comments in ORMGeneratorSelectionControl.OnClosed
+				string tmpFile = null;
 				bool boundBuildItemsChanged = true;
-				while (boundBuildItemsChanged)
-				{
-					boundBuildItemsChanged = false;
-					int i = 0;
-					while (i < boundBuildItems.Count)
-					{
-						BoundBuildItem boundBuildItem = boundBuildItems[i];
+				Dictionary<string, string> inputFormatToSignature = null;
+				Dictionary<string, int> currentTargetedFormats = null; // Value is the index of the original build item that triggered this, allowing the structure to be copied.
+				int buildItemCount = boundBuildItems.Count;
+				int originalBuildItemCount = buildItemCount;
+				BitTracker buildItemProcessed = new BitTracker(buildItemCount);
+				int remainingBuildItemCount = buildItemCount;
+				int iMinBuildItem = 0;
+				int iBuildItem = 0;
+				bool processingExtraBuildItems = false;
 #if VISUALSTUDIO_10_0
-						ProjectItemElement buildItem = boundBuildItem.BuildItem;
+				List<ProjectItemElement> removeBuildItems = null;
 #else
-						BuildItem buildItem = boundBuildItem.BuildItem;
+				List<BuildItem> removeBuildItems = null;
 #endif
-						IORMGenerator ormGenerator = boundBuildItem.ORMGenerator;
-						try
+
+				Action stepLoop = delegate ()
+				{
+					buildItemProcessed[iBuildItem] = true;
+					if (iBuildItem == iMinBuildItem)
+					{
+						++iMinBuildItem;
+					}
+					++iBuildItem;
+					--remainingBuildItemCount;
+					if (!processingExtraBuildItems)
+					{
+						pGenerateProgress.Progress(++progressCurrent, progressTotal);
+					}
+					boundBuildItemsChanged = true;
+				};
+
+				Action registerRemoveBuildItem = delegate ()
+				{
+#if VISUALSTUDIO_10_0
+					ProjectItemElement item;
+#else
+					BuildItem item;
+#endif
+					item = boundBuildItems[iBuildItem].BuildItem;
+					(removeBuildItems ?? (removeBuildItems =
+#if VISUALSTUDIO_10_0
+					new List<ProjectItemElement>()
+#else
+					new List<BuildItem>()
+#endif
+					)).Add(item);
+					try
+					{
+						EnvDTE.ProjectItem subItem = projectItems.Item(ORMCustomToolUtility.GetItemInclude(item));
+						if (subItem != null)
 						{
-							IList<string> requiresInputFormats = ormGenerator.RequiresInputFormats;
-							string outputFormat = ormGenerator.ProvidesOutputFormat;
-							bool missingInputFormat = false;
-							foreach (string inputFormat in requiresInputFormats)
+							// This will delete the existing file, which might be regenerated with
+							// under a new build item later. Do not defer this or we'll delete a file
+							// we just created.
+							subItem.Delete();
+						}
+					}
+					catch (ArgumentException)
+					{
+						// Swallow
+					}
+				};
+
+				Action<string> targetOutputFormat = delegate (string outputFormat)
+				{
+					// This is handling the possibility that the set of generator target names changed since the
+					// dialog was run. Given that target instances will all have the same dependency structure
+					// we make sure that if we encounter one instance that all new instances generate, and that
+					// all obsolete instances are deleted.
+					if (currentTargetedFormats == null)
+					{
+						currentTargetedFormats = new Dictionary<string, int>();
+						currentTargetedFormats[outputFormat] = iBuildItem;
+					}
+					else if (!currentTargetedFormats.ContainsKey(outputFormat))
+					{
+						currentTargetedFormats[outputFormat] = iBuildItem;
+					}
+				};
+
+				try
+				{
+					while (boundBuildItemsChanged)
+					{
+						iBuildItem = iMinBuildItem;
+						processingExtraBuildItems = false;
+
+						if (currentTargetedFormats != null && currentTargetedFormats.Count != 0)
+						{
+							int incrementalBuildItemCount = 0;
+							foreach (KeyValuePair<string, int> kvp in currentTargetedFormats)
 							{
-								int lastFormatStep;
-								if (!(lastFormatSteps.TryGetValue(inputFormat, out lastFormatStep) &&
-									(lastFormatStep < 0 || // Indicates a completed format, ignore if not next modifier
-									(inputFormat == ormGenerator.ProvidesOutputFormat && boundBuildItem.IsNextFormatStep(lastFormatStep)))))
+								ORMCustomToolUtility.GeneratorTargetSet targetSet = null;
+								BitTracker formatStatus = processedGeneratorTargets[kvp.Key];
+								for (int iInstance = 0, instanceCount = formatStatus.Count; iInstance < instanceCount; ++iInstance)
 								{
-									missingInputFormat = true;
-									break;
-								}
-							}
-							if (missingInputFormat)
-							{
-								// Go on to the next generator, we'll (probably) come back to this one
-								++i;
-								continue;
-							}
-							else
-							{
-								string fullItemPath = Path.Combine(projectDirectory ?? (projectDirectory = Path.GetDirectoryName(projectPath)), ORMCustomToolUtility.GetItemInclude(buildItem));
-								FileInfo checkExisting;
-								bool useExisting = ormGenerator.GeneratesOnce && (checkExisting = new FileInfo(fullItemPath)).Exists && checkExisting.Length != 0;
-								Stream readonlyOutputStream = null;
-								MemoryStream outputStream = null;
-								int outputStreamLength = 0;
-								if (!useExisting)
-								{
-									outputStream = new MemoryStream();
-									try
+									if (formatStatus[iInstance])
 									{
-										// UNDONE: Extension checking should happen in the current generator
-										// going back to the generator that produced the input file. We're only
-										// extending ORM files right now, and the ORM file doesn't have a generator,
-										// so we just do it here.
-										bool extensionsSatisfied = true;
-										foreach (string extension in ormGenerator.GetRequiredExtensionsForInputFormat(ORM_OUTPUT_FORMAT))
-										{
-											if (null == ormExtensions)
-											{
-												ormExtensions = ormExtensionManager.GetLoadedExtensions(_serviceProvider);
-											}
-											if (Array.BinarySearch<string>(ormExtensions, extension) < 0)
-											{
-												extensionsSatisfied = false;
-												// UNDONE: Localize error messages.
-												report(
-													string.Format(CultureInfo.InvariantCulture, "The extension '{0}' in the '{1}' is required for generation of the '{2}' file. The existing contents of '{3}' will not be modified. Open the 'ORM Generator Selection' dialog and choose 'Save Changes' to automatically add required extensions.", extension, ORM_OUTPUT_FORMAT, ormGenerator.OfficialName, ORMCustomToolUtility.GetItemInclude(buildItem)),
-													ReportType.Error,
-													null);
-											}
-										}
-										if (extensionsSatisfied)
-										{
-											ormGenerator.GenerateOutput(buildItem, outputStream, readonlyOutputFormatStreams, wszDefaultNamespace, itemProperties);
-											readonlyOutputStream = new ReadOnlyStream(outputStream);
-										}
+										continue;
 									}
-									catch (Exception ex)
+
+									GeneratorTarget[] missedInstance = (targetSet ?? (targetSet = targetSetsByFormatName[kvp.Key])).Instances[iInstance];
+									int primaryBuildItemIndex = kvp.Value;
+									int lastBuildItemIndex = primaryBuildItemIndex;
+
+									// Find primary generator based on FormatStep. Note that the BoundBuildItem contents
+									// are always added in order and we don't change the set, so format steps for the same
+									// item are always grouped.
+									BoundBuildItem primaryBuildItem = boundBuildItems[primaryBuildItemIndex];
+									int formatStep = primaryBuildItem.FormatStep;
+									if (formatStep != ~0)
 									{
-										// UNDONE: Localize error messages.
-										report(
-											string.Format(CultureInfo.InvariantCulture, "Exception occurred while executing transform '{0}'. The existing contents of '{1}' will not be modified.", ormGenerator.OfficialName, ORMCustomToolUtility.GetItemInclude(buildItem)),
-											ReportType.Error,
-											ex);
-									}
-									outputStreamLength = (int)outputStream.Length;
-								}
-								lastFormatSteps[outputFormat] = boundBuildItem.FormatStep;
-
-								bool textLinesReloadRequired;
-								IVsTextLines textLines = GetTextLinesForDocument(fullItemPath, out textLinesReloadRequired);
-								// Write the result out to the appropriate file...
-								if (textLines != null)
-								{
-									// Get edit points in the document to read the full file from
-									// the in-memory editor
-									object editPointStartObject;
-									ErrorHandler.ThrowOnFailure(textLines.CreateEditPoint(0, 0, out editPointStartObject));
-									EnvDTE.EditPoint editPointStart = editPointStartObject as EnvDTE.EditPoint;
-									Debug.Assert(editPointStart != null);
-									EnvDTE.EditPoint editPointEnd = editPointStart.CreateEditPoint();
-									editPointEnd.EndOfDocument();
-
-									if (readonlyOutputStream != null)
-									{
-										// Reset outputStream to the beginning of the stream...
-										outputStream.Seek(0, SeekOrigin.Begin);
-
-										// We're using the readonlyOutputStream here so that the StreamReader can't close the real stream
-										using (StreamReader streamReader = new StreamReader(readonlyOutputStream, Encoding.UTF8, true, (int)outputStreamLength))
+										if (formatStep < 0)
 										{
-											// We're not passing any flags to ReplaceText, because the output of the generators should
-											// be the same whether or not the user has the generated document open
-											editPointStart.ReplaceText(editPointEnd, streamReader.ReadToEnd(), 0);
-											if (textLinesReloadRequired)
+											primaryBuildItemIndex -= ~formatStep;
+										}
+										else
+										{
+											primaryBuildItemIndex -= formatStep;
+
+											while (formatStep >= 0)
 											{
-												// If a textlines is available from the DocData but not the
-												// DocView, then the view may not refresh if we simply update
-												// the text lines, so we force a reload at this point.
-												// This works with the xml schema editors (the default view
-												// for an xsd file), which is the only case we've hit
-												// so far that causes problems.
-												ErrorHandler.ThrowOnFailure(textLines.Reload(1));
+												formatStep = boundBuildItems[++lastBuildItemIndex].FormatStep;
+												if (formatStep < 0)
+												{
+													break;
+												}
 											}
 										}
-										IVsPersistDocData2 persist = textLines as IVsPersistDocData2;
-										if (persist != null)
+										primaryBuildItem = boundBuildItems[primaryBuildItemIndex];
+									}
+
+									GeneratorTarget[] targetInstance = targetSetsByFormatName[kvp.Key].Instances[iInstance];
+									string defaultFileName = primaryBuildItem.ORMGenerator.GetOutputFileDefaultName(sourceFileName);
+									string fileName = targetInstance == null ? defaultFileName : ORMCustomToolUtility.GeneratorTargetSet.DecorateFileName(defaultFileName, targetInstance);
+									string fileRelativePath = Path.Combine(newItemDirectory, fileName);
+									string fileAbsolutePath = string.Concat(new FileInfo(projectPath).DirectoryName, Path.DirectorySeparatorChar, fileRelativePath);
+
+#if VISUALSTUDIO_10_0
+									ProjectItemElement newBuildItem;
+									if (ormItemGroup.Parent == null)
+									{
+										// If the set of items dropped to empty then the item group can delete itself. Recreate it.
+										ormItemGroup = project.AddItemGroup();
+#else
+									BuildItem newBuildItem;
+									if (ormItemGroup.Count == 0)
+									{
+										ormItemGroup = project.AddNewItemGroup();
+#endif
+										ormItemGroup.Condition = string.Concat(ITEMGROUP_CONDITIONSTART, projectItemRelPath, ITEMGROUP_CONDITIONEND);
+									}
+
+									newBuildItem = primaryBuildItem.ORMGenerator.AddGeneratedFileItem(ormItemGroup, sourceFileName, fileRelativePath);
+									ORMCustomToolUtility.SetGeneratorTargetMetadata(newBuildItem, targetInstance);
+									if (primaryBuildItemIndex != lastBuildItemIndex)
+									{
+										// Multiple generators, adjust the generator name metadata.
+										string[] generatorNames = new string[lastBuildItemIndex - primaryBuildItemIndex + 1];
+										for (int i = 0, count = generatorNames.Length; i < count; ++i)
 										{
-											int dirtyFlag;
-											if (ErrorHandler.Succeeded(persist.IsDocDataDirty(out dirtyFlag)) && dirtyFlag != 0)
-											{
-												string bstrMkDocumentNew;
-												int fSaveCanceled;
-												persist.SaveDocData(VSSAVEFLAGS.VSSAVE_Save, out bstrMkDocumentNew, out fSaveCanceled);
-											}
+											generatorNames[i] = boundBuildItems[i + primaryBuildItemIndex].ORMGenerator.OfficialName;
+										}
+										ORMCustomToolUtility.SetItemMetaData(newBuildItem, ITEMMETADATA_ORMGENERATOR, string.Join(" ", generatorNames));
+									}
+
+									(sideEffectItemNames ?? (sideEffectItemNames = new Dictionary<string, string>()))[fileRelativePath] = null;
+									if (File.Exists(fileAbsolutePath))
+									{
+										try
+										{
+											projectItems.AddFromFile(fileAbsolutePath);
+										}
+										catch (ArgumentException)
+										{
+											// Swallow
 										}
 									}
 									else
 									{
-										if (outputStream != null)
+										if (tmpFile == null)
 										{
-											// Reset outputStream to the beginning of the stream...
-											outputStream.Seek(0, SeekOrigin.Begin);
+											tmpFile = Path.GetTempFileName();
+										}
+										EnvDTE.ProjectItem newProjectItem = projectItems.AddFromTemplate(tmpFile, fileName);
+										string customTool;
+										if (!string.IsNullOrEmpty(customTool = newBuildItem.GetMetadata(ITEMMETADATA_GENERATOR)))
+										{
+											newProjectItem.Properties.Item("CustomTool").Value = customTool;
+										}
+									}
+
+									// Extend the set we're processing in the main loop
+									bindBuildItem(
+										newBuildItem,
+										delegate (BoundBuildItem boundItem)
+										{
+											boundBuildItems.Add(boundItem);
+											++incrementalBuildItemCount;
+										},
+										null);
+								}
+							}
+
+							if (incrementalBuildItemCount != 0)
+							{
+								// Hijack the loop by dynamically adding bound build items
+								processingExtraBuildItems = true;
+								iBuildItem = buildItemCount;
+								buildItemCount += incrementalBuildItemCount;
+								remainingBuildItemCount += incrementalBuildItemCount;
+								buildItemProcessed.Resize(buildItemCount);
+							}
+							currentTargetedFormats.Clear();
+						}
+
+						boundBuildItemsChanged = false;
+						while (remainingBuildItemCount != 0 && iBuildItem < buildItemCount)
+						{
+							bool canMoveMin = iBuildItem == iMinBuildItem; // If items are skipped in the original list then the min item may be higher than it currently is.
+							while (buildItemProcessed[iBuildItem])
+							{
+								++iBuildItem;
+								if (canMoveMin)
+								{
+									++iMinBuildItem;
+								}
+							}
+
+							BoundBuildItem boundBuildItem = boundBuildItems[iBuildItem];
+#if VISUALSTUDIO_10_0
+							ProjectItemElement buildItem = boundBuildItem.BuildItem;
+#else
+							BuildItem buildItem = boundBuildItem.BuildItem;
+#endif
+							IORMGenerator ormGenerator = boundBuildItem.ORMGenerator;
+							try
+							{
+								IList<string> requiresInputFormats = ormGenerator.RequiresInputFormats;
+								string outputFormat = ormGenerator.ProvidesOutputFormat;
+								string outputSignature = boundBuildItem.Signature;
+								int outputInstanceIndex = -1;
+								GeneratorTarget[] outputInstance = null;
+								ORMCustomToolUtility.GeneratorTargetSet outputTargetSet = null;
+
+								if (boundBuildItem.TargetInstance != null)
+								{
+									if (generatorTargetsBySignature != null)
+									{
+										// If the outputFormat does not map to an outputTargetSet then
+										// we've essentially replaced a generator that uses generator targets
+										// to another one that does not. We could potentially handle this
+										// by just removing the generator target metadata elements, but this
+										// will likely leave us with the wrong file name.
+										// In practice this is not something that will actually happen because
+										// a generator change should only happen in the dialog, not during a custom tool
+										// execution. The only thing we're handling here is a change in the generator
+										// target data, not changes to the generator itself, so we punt on this
+										// scenario and simply remove the item.
+										if (targetSetsByFormatName.TryGetValue(outputFormat, out outputTargetSet) &&
+											generatorTargetsBySignature.TryGetValue(outputSignature, out outputInstanceIndex))
+										{
+											outputInstance = outputTargetSet.Instances[outputInstanceIndex];
 										}
 										else
 										{
-											// Handle the 'useExisting' case
-											outputStream = new MemoryStream();
+											// The instance didn't match anything we currently have, so this is not processed, just deleted.
+											targetOutputFormat(outputFormat);
+											registerRemoveBuildItem();
+											stepLoop();
+											continue;
 										}
-
-										// The file did not generate, use what we had before if it already exists
-										using (StreamWriter writer = new StreamWriter(new UncloseableStream(outputStream), Encoding.UTF8))
-										{
-											writer.Write(editPointStart.GetText(editPointEnd));
-											writer.Flush();
-										}
-										outputStream.SetLength(outputStream.Position);
-										readonlyOutputStream = new ReadOnlyStream(outputStream);
+									}
+									else
+									{
+										// See comments above. This should only occur if the generator itself changes.
+										// This should be extremely rare given that we're auto-filling in placeholders.
+										// There is no way to handle the TargetInstance here, so we just delete the item.
+										registerRemoveBuildItem();
+										stepLoop();
+										continue;
 									}
 								}
-								else if (readonlyOutputStream == null)
+
+								bool missingInputFormat = false;
+								bool hasModifiedInputSignatures = false;
+								foreach (string inputFormat in requiresInputFormats)
 								{
-									if (outputStream != null)
+									string inputSignature = inputFormat;
+									ORMCustomToolUtility.GeneratorTargetSet inputTargetSet = null;
+									IList<int> inputIndicesInOutput = null;
+									if (targetSetsByFormatName != null &&
+										outputTargetSet != null &&
+										targetSetsByFormatName.TryGetValue(inputFormat, out inputTargetSet) &&
+										null != (inputIndicesInOutput = outputTargetSet.MatchInputTargetTypes(inputTargetSet.TargetTypes))) // Defensive null check, we should always have an output set if an input has a target set
 									{
-										// The transform failed and the file is not loaded in the
-										// environment. Attempt to load it from disk. The output
-										// stream is no longer needed, shut it down now.
-										outputStream.Close();
+										if (!hasModifiedInputSignatures)
+										{
+											hasModifiedInputSignatures = true;
+											if (inputFormatToSignature != null)
+											{
+												inputFormatToSignature.Clear();
+											}
+											else
+											{
+												inputFormatToSignature = new Dictionary<string, string>();
+											}
+										}
+										inputSignature = BoundBuildItem.BuildSignature(inputFormat, outputInstance, inputIndicesInOutput);
+										inputFormatToSignature[inputFormat] = inputSignature;
 									}
-									if (useExisting || File.Exists(fullItemPath))
+									int lastFormatStep;
+									if (!(lastFormatSteps.TryGetValue(inputSignature, out lastFormatStep) &&
+										(lastFormatStep < 0 || // Indicates a completed format, ignore if not next modifier
+										(inputFormat == outputFormat && boundBuildItem.IsNextFormatStep(lastFormatStep)))))
 									{
-										readonlyOutputStream = new ReadOnlyStream(new FileStream(fullItemPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite));
+										missingInputFormat = true;
+										break;
 									}
+								}
+								if (missingInputFormat)
+								{
+									// Go on to the next generator, we'll (probably) come back to this one
+									++iBuildItem;
+									continue;
 								}
 								else
 								{
-									bool retriedOpenFileStream = false;
-								LABEL_OPEN_FILESTREAM:
-									FileStream fileStream = null;
-									try
+									if (generatorTargetsBySignature != null && boundBuildItem.TargetInstance != null)
 									{
-										fileStream = File.Create(fullItemPath, outputStreamLength, FileOptions.SequentialScan);
-										fileStream.Write(outputStream.GetBuffer(), 0, outputStreamLength);
-									}
-									catch (IOException)
-									{
-										// Something seems to keep the files locked occasionally (especially the larger ones), so
-										// retry once after a brief wait if we get an IOException the first time we try to to open it.
-										if (!retriedOpenFileStream)
-										{
-											retriedOpenFileStream = true;
-											System.Threading.Thread.Sleep(150);
-											goto LABEL_OPEN_FILESTREAM;
-										}
-										throw;
-									}
-									finally
-									{
-										if (fileStream != null)
-										{
-											fileStream.Close();
-										}
-									}
-								}
+										targetOutputFormat(outputFormat);
 
-								if (readonlyOutputStream != null)
-								{
-									// Save the stream for future use
-									outputFormatStreams[ormGenerator.ProvidesOutputFormat] = readonlyOutputStream; // Use indexer in case this is an update
-									// Reset outputStream to the beginning of the stream...
-									readonlyOutputStream.Seek(0, SeekOrigin.Begin);
-								}
+										// Signature matching ignores placeholder status, so we don't actually
+										// know if a build item has the placeholder state set correctly unless
+										// we created the build item during this pass through the generator.
+										if (iBuildItem < originalBuildItemCount)
+										{
+											ORMCustomToolUtility.UpdateGeneratorTargetPlaceholders(buildItem, outputInstance);
+										}
 
-								boundBuildItems.RemoveAt(i);
-								pGenerateProgress.Progress(++progressCurrent, progressTotal);
-								// Item was removed, do not increment the counter
-								boundBuildItemsChanged = true;
+										// Mark as processed regardless of the result below here, including failure and deletion.
+										BitTracker tracker = processedGeneratorTargets[outputFormat];
+										tracker[outputInstanceIndex] = true;
+										processedGeneratorTargets[outputFormat] = tracker;
+									}
+
+									string fullItemPath = Path.Combine(projectDirectory, ORMCustomToolUtility.GetItemInclude(buildItem));
+									FileInfo checkExisting;
+									bool useExisting = ormGenerator.GeneratesOnce && (checkExisting = new FileInfo(fullItemPath)).Exists && checkExisting.Length != 0;
+									Stream readonlyOutputStream = null;
+									MemoryStream outputStream = null;
+									int outputStreamLength = 0;
+									if (!useExisting)
+									{
+										outputStream = new MemoryStream();
+										try
+										{
+											// UNDONE: Extension checking should happen in the current generator
+											// going back to the generator that produced the input file. We're only
+											// extending ORM files right now, and the ORM file doesn't have a generator,
+											// so we just do it here.
+											bool extensionsSatisfied = true;
+											foreach (string extension in ormGenerator.GetRequiredExtensionsForInputFormat(ORM_OUTPUT_FORMAT))
+											{
+												if (null == ormExtensions)
+												{
+													ormExtensions = ormExtensionManager.GetLoadedExtensions(_serviceProvider);
+												}
+												if (Array.BinarySearch<string>(ormExtensions, extension) < 0)
+												{
+													extensionsSatisfied = false;
+													// UNDONE: Localize error messages.
+													report(
+														string.Format(CultureInfo.InvariantCulture, "The extension '{0}' in the '{1}' is required for generation of the '{2}' file. The existing contents of '{3}' will not be modified. Open the 'ORM Generator Selection' dialog and choose 'Save Changes' to automatically add required extensions.", extension, ORM_OUTPUT_FORMAT, ormGenerator.OfficialName, ORMCustomToolUtility.GetItemInclude(buildItem)),
+														ReportType.Error,
+														null);
+												}
+											}
+											if (extensionsSatisfied)
+											{
+												GetFormatStream streamLookup = hasModifiedInputSignatures ?
+													(GetFormatStream)delegate (string formatName)
+													{
+														string decoratedFormatName;
+														Stream stream;
+														return readonlyOutputFormatStreams.TryGetValue(inputFormatToSignature.TryGetValue(formatName, out decoratedFormatName) ? decoratedFormatName : formatName, out stream) ? stream : null;
+													}
+												:
+													delegate (string formatName)
+													{
+														Stream stream;
+														return readonlyOutputFormatStreams.TryGetValue(formatName, out stream) ? stream : null;
+													};
+												ormGenerator.GenerateOutput(buildItem, outputStream, streamLookup, wszDefaultNamespace, itemProperties, outputInstance);
+												readonlyOutputStream = new ReadOnlyStream(outputStream);
+											}
+										}
+										catch (Exception ex)
+										{
+											// UNDONE: Localize error messages.
+											report(
+												string.Format(CultureInfo.InvariantCulture, "Exception occurred while executing transform '{0}'. The existing contents of '{1}' will not be modified.", ormGenerator.OfficialName, ORMCustomToolUtility.GetItemInclude(buildItem)),
+												ReportType.Error,
+												ex);
+										}
+										outputStreamLength = (int)outputStream.Length;
+									}
+									lastFormatSteps[outputSignature] = boundBuildItem.FormatStep;
+
+									bool textLinesReloadRequired;
+									IVsTextLines textLines = GetTextLinesForDocument(fullItemPath, out textLinesReloadRequired);
+									// Write the result out to the appropriate file...
+									if (textLines != null)
+									{
+										// Get edit points in the document to read the full file from
+										// the in-memory editor
+										object editPointStartObject;
+										ErrorHandler.ThrowOnFailure(textLines.CreateEditPoint(0, 0, out editPointStartObject));
+										EnvDTE.EditPoint editPointStart = editPointStartObject as EnvDTE.EditPoint;
+										Debug.Assert(editPointStart != null);
+										EnvDTE.EditPoint editPointEnd = editPointStart.CreateEditPoint();
+										editPointEnd.EndOfDocument();
+
+										if (readonlyOutputStream != null)
+										{
+											// Reset outputStream to the beginning of the stream...
+											outputStream.Seek(0, SeekOrigin.Begin);
+
+											// We're using the readonlyOutputStream here so that the StreamReader can't close the real stream
+											using (StreamReader streamReader = new StreamReader(readonlyOutputStream, Encoding.UTF8, true, (int)outputStreamLength))
+											{
+												// We're not passing any flags to ReplaceText, because the output of the generators should
+												// be the same whether or not the user has the generated document open
+												editPointStart.ReplaceText(editPointEnd, streamReader.ReadToEnd(), 0);
+												if (textLinesReloadRequired)
+												{
+													// If a textlines is available from the DocData but not the
+													// DocView, then the view may not refresh if we simply update
+													// the text lines, so we force a reload at this point.
+													// This works with the xml schema editors (the default view
+													// for an xsd file), which is the only case we've hit
+													// so far that causes problems.
+													ErrorHandler.ThrowOnFailure(textLines.Reload(1));
+												}
+											}
+											IVsPersistDocData2 persist = textLines as IVsPersistDocData2;
+											if (persist != null)
+											{
+												int dirtyFlag;
+												if (ErrorHandler.Succeeded(persist.IsDocDataDirty(out dirtyFlag)) && dirtyFlag != 0)
+												{
+													string bstrMkDocumentNew;
+													int fSaveCanceled;
+													persist.SaveDocData(VSSAVEFLAGS.VSSAVE_Save, out bstrMkDocumentNew, out fSaveCanceled);
+												}
+											}
+										}
+										else
+										{
+											if (outputStream != null)
+											{
+												// Reset outputStream to the beginning of the stream...
+												outputStream.Seek(0, SeekOrigin.Begin);
+											}
+											else
+											{
+												// Handle the 'useExisting' case
+												outputStream = new MemoryStream();
+											}
+
+											// The file did not generate, use what we had before if it already exists
+											using (StreamWriter writer = new StreamWriter(new UncloseableStream(outputStream), Encoding.UTF8))
+											{
+												writer.Write(editPointStart.GetText(editPointEnd));
+												writer.Flush();
+											}
+											outputStream.SetLength(outputStream.Position);
+											readonlyOutputStream = new ReadOnlyStream(outputStream);
+										}
+									}
+									else if (readonlyOutputStream == null)
+									{
+										if (outputStream != null)
+										{
+											// The transform failed and the file is not loaded in the
+											// environment. Attempt to load it from disk. The output
+											// stream is no longer needed, shut it down now.
+											outputStream.Close();
+										}
+										if (useExisting || File.Exists(fullItemPath))
+										{
+											readonlyOutputStream = new ReadOnlyStream(new FileStream(fullItemPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite));
+										}
+									}
+									else
+									{
+										bool retriedOpenFileStream = false;
+										LABEL_OPEN_FILESTREAM:
+										FileStream fileStream = null;
+										try
+										{
+											fileStream = File.Create(fullItemPath, outputStreamLength, FileOptions.SequentialScan);
+											fileStream.Write(outputStream.GetBuffer(), 0, outputStreamLength);
+										}
+										catch (IOException)
+										{
+											// Something seems to keep the files locked occasionally (especially the larger ones), so
+											// retry once after a brief wait if we get an IOException the first time we try to to open it.
+											if (!retriedOpenFileStream)
+											{
+												retriedOpenFileStream = true;
+												System.Threading.Thread.Sleep(150);
+												goto LABEL_OPEN_FILESTREAM;
+											}
+											throw;
+										}
+										finally
+										{
+											if (fileStream != null)
+											{
+												fileStream.Close();
+											}
+										}
+									}
+
+									if (readonlyOutputStream != null)
+									{
+										// Save the stream for future use
+										outputFormatStreams[outputSignature] = readonlyOutputStream; // Use indexer in case this is an update
+				
+										// Reset outputStream to the beginning of the stream
+										readonlyOutputStream.Seek(0, SeekOrigin.Begin);
+									}
+
+									stepLoop();
+									continue;
+								}
+							}
+							catch (Exception ex)
+							{
+								// UNDONE: Localize error message.
+								report(
+									string.Format(CultureInfo.InvariantCulture, "Error occurred during generation of '{0}' via IORMGenerator '{1}'.", ORMCustomToolUtility.GetItemInclude(buildItem), ormGenerator.OfficialName),
+									ReportType.Error,
+									ex);
+								stepLoop();
 								continue;
 							}
 						}
-						catch (Exception ex)
+					}
+					if (removeBuildItems != null)
+					{
+#if VISUALSTUDIO_10_0
+						foreach (ProjectItemElement removeBuildItem in removeBuildItems)
 						{
-							// UNDONE: Localize error message.
-							report(
-								string.Format(CultureInfo.InvariantCulture, "Error occurred during generation of '{0}' via IORMGenerator '{1}'.", ORMCustomToolUtility.GetItemInclude(buildItem), ormGenerator.OfficialName),
-								ReportType.Error,
-								ex);
-							boundBuildItems.RemoveAt(i);
-							pGenerateProgress.Progress(++progressCurrent, progressTotal);
-							// Item was removed, do not increment the counter
-							boundBuildItemsChanged = true;
-							continue;
+							ProjectElementContainer removeFrom;
+							if (null != (removeFrom = removeBuildItem.Parent))
+							{
+								removeFrom.RemoveChild(removeBuildItem);
+							}
+#else // VISUALSTUDIO_10_0
+						foreach (BuildItem removeBuildItem in removeBuildItems)
+						{
+							project.RemoveItem(removeBuildItem);
+#endif // VISUALSTUDIO_10_0
 						}
 					}
+				}
+				finally
+				{
+					if (tmpFile != null)
+					{
+						File.Delete(tmpFile);
+					}
+				}
+
+				if (sideEffectItemNames != null)
+				{
+					ORMCustomToolUtility.RemoveSideEffectItems(sideEffectItemNames, project, ormItemGroup);
 				}
 
 				pGenerateProgress.Progress(++progressCurrent, progressTotal);
@@ -1032,7 +1560,7 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 					}
 				}
 
-				foreach (EnvDTE.ProjectItem childProjectItem in projectItem.ProjectItems)
+				foreach (EnvDTE.ProjectItem childProjectItem in projectItems)
 				{
 					EnvDTE.Property customToolProperty = childProjectItem.Properties.Item("CustomTool");
 					if (customToolProperty != null && !string.IsNullOrEmpty(customToolProperty.Value as string))
@@ -1057,6 +1585,353 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 	/// </summary>
 	internal static class ORMCustomToolUtility
 	{
+		// Suffix is index then _ then the target type, value is the name (not the id)
+		private const string ITEMMETADATA_ORMGENERATORTARGET_PREFIX = "ORMGeneratorTarget_";
+		private const string ITEMMETADATA_ORMGENERATORTARGET_PLACEHOLDERS = "ORMGeneratorTargetPlaceholders";
+
+		/// <summary>
+		/// A wrapper to enable use of a list of generator target type names
+		/// as a key.
+		/// </summary>
+		public class GeneratorTargetSet
+		{
+#region Member variables and constructor
+			private readonly IList<string> myTargetTypes;
+			private readonly IList<string> myReadOnlyTargetTypes;
+			private GeneratorTarget[][] myGeneratorInstances;
+			/// <summary>
+			/// Create a new <see cref="GeneratorTargetSet"/> from a list of target names.
+			/// </summary>
+			public GeneratorTargetSet(List<string> targetNames)
+			{
+				// Keep the original data so we can do instance checking on the original collection
+				myTargetTypes = (IList<string>)targetNames ?? Array.Empty<string>();
+				myReadOnlyTargetTypes = targetNames != null ? targetNames.AsReadOnly() : myTargetTypes;
+			}
+#endregion // Member variables and constructor
+#region Accessor properties
+			/// <summary>
+			/// Get the ordered target names associated with this set.
+			/// </summary>
+			public IList<string> TargetTypes
+			{
+				get
+				{
+					return myReadOnlyTargetTypes;
+				}
+			}
+			/// <summary>
+			/// Get or set the instances for this target set.
+			/// </summary>
+			/// <remarks>For any given use of this target set the individual instances
+			/// for each target type will be known and the combinations will not change.
+			/// This provides a convenient location to store this data with the associated
+			/// key. This data is not included in any equality check. This can be assigned
+			/// to the return value from <see cref="PopulateInstances"/></remarks>
+			public GeneratorTarget[][] Instances
+			{
+				get
+				{
+					return myGeneratorInstances;
+				}
+				set
+				{
+					myGeneratorInstances = value;
+				}
+			}
+			/// <summary>
+			/// Find the index of the given targets in the current instances
+			/// </summary>
+			/// <param name="targets">Array of targets.</param>
+			/// <param name="nonPreferredInstance">Set and return true to deprioritize an instance in the target set.
+			/// The instance will only be returned if no other item is available. This allows for duplicate discovery.</param>
+			/// <returns>Instance index, or -1 if not found.</returns>
+			public int IndexOfInstance(GeneratorTarget[] targets, Predicate<int> nonPreferredInstance)
+			{
+				GeneratorTarget[][] instances;
+				int firstNonPreferred = -1;
+				if (targets != null &&
+					(instances = myGeneratorInstances) != null)
+				{
+					int targetCount = targets.Length;
+					for (int instance = 0; instance < instances.Length; ++instance)
+					{
+						bool notPreferred = nonPreferredInstance != null && nonPreferredInstance(instance);
+
+						GeneratorTarget[] instanceTargets = instances[instance];
+						if (instanceTargets.Length == targets.Length)
+						{
+							int i = 0;
+							for (; i < targetCount; ++i)
+							{
+								if (instanceTargets[i] != targets[i])
+								{
+									break;
+								}
+							}
+							if (i == targetCount)
+							{
+								if (notPreferred)
+								{
+									if (firstNonPreferred == -1)
+									{
+										firstNonPreferred = instance;
+									}
+								}
+								else
+								{
+									return instance;
+								}
+							}
+						}
+					}
+				}
+				return firstNonPreferred;
+			}
+			/// <summary>
+			/// Assuming these is an expanded target set, the overlapping target types
+			/// for any input format must be a subset of the target types for this instance.
+			/// Extracting the matching input types allows us to find the correct input,
+			/// which will have the same generator target names for the overlapping target types.
+			/// </summary>
+			/// <param name="inputTargetTypes">The target types from the input generator set.</param>
+			/// <returns>A list of matching indices, or null.</returns>
+			public IList<int> MatchInputTargetTypes(IList<string> inputTargetTypes)
+			{
+				if (inputTargetTypes == null)
+				{
+					return null;
+				}
+				// Furthermore, the target types must occur in the same order in the downstream type
+				IList<string> currentTargetTypes = myReadOnlyTargetTypes;
+				int currentTypeCount = currentTargetTypes.Count;
+				int iCurrent = -1;
+				int inputTypeCount = inputTargetTypes.Count;
+				int iInput = 0;
+				List<int> retVal = null;
+				for (; iInput < inputTypeCount; ++iInput)
+				{
+					++iCurrent;
+					string inputType = inputTargetTypes[iInput];
+					for (; iCurrent < currentTypeCount; ++iCurrent)
+					{
+						if (0 == string.Compare(inputType, currentTargetTypes[iCurrent], StringComparison.OrdinalIgnoreCase))
+						{
+							(retVal ?? (retVal = new List<int>())).Add(iCurrent);
+							break;
+						}
+					}
+					if (iCurrent == currentTypeCount)
+					{
+						retVal = null;
+						break;
+					}
+				}
+				return iInput < inputTypeCount ? null : retVal;
+			}
+			/// <summary>
+			/// Inject generator target names into a generator-default file name.
+			/// The target names are placed immediately before the final file extension.
+			/// </summary>
+			public static string DecorateFileName(string fileName, GeneratorTarget[] targets)
+			{
+				int nextName = 0;
+				int count = targets.Length;
+				string[] names = null;
+				for (int i = 0; i < count; ++i)
+				{
+					string name = targets[i].TargetName;
+					if (!string.IsNullOrEmpty(name))
+					{
+						if (names == null)
+						{
+							names = new string[count + 1];
+							names[0] = string.Empty; // We want a leading . separator, leave extra slot
+							nextName = 1;
+						}
+						names[nextName] = name;
+						++nextName;
+					}
+				}
+				if (names != null)
+				{
+					string withoutSuffix = Path.GetFileNameWithoutExtension(fileName);
+					return withoutSuffix + string.Join(".", names, 0, nextName) + fileName.Substring(withoutSuffix.Length);
+				}
+				return fileName;
+			}
+#endregion // Accessor properties
+#region Instance expansion
+			/// <summary>
+			/// Generate all instance combinations matching the targets
+			/// </summary>
+			/// <param name="activeTargets">Dictionary keyed by target type with active targets.</param>
+			/// <returns>Array of GeneratorTarget arrays representing all combinations of active
+			/// targets. Instances must be fully populated, so if any of the types are not represented
+			/// by a generator target then this returns null.</returns>
+			public GeneratorTarget[][] PopulateInstances(IDictionary<string, GeneratorTarget[]> activeTargets)
+			{
+				IList<string> types = myTargetTypes;
+				int typeCount = types.Count;
+				int targetCount;
+				GeneratorTarget[] targetList;
+				GeneratorTarget[][] retVal = null;
+				if (typeCount == 1)
+				{
+					if (activeTargets == null || !activeTargets.TryGetValue(types[0], out targetList) || 0 == (targetCount = targetList.Length))
+					{
+						retVal = new GeneratorTarget[1][];
+						retVal[0] = new GeneratorTarget[] { new GeneratorTarget(types[0], null, null) };
+					}
+					else
+					{
+						retVal = new GeneratorTarget[targetCount][];
+						for (int i = 0; i < targetCount; ++i)
+						{
+							retVal[i] = new GeneratorTarget[1] { targetList[i] };
+						}
+					}
+				}
+				else
+				{
+					// Make sure we have something for each list
+					GeneratorTarget[][] simpleTargets = new GeneratorTarget[typeCount][];
+					int instanceCount = 1;
+					for (int i = 0; i < typeCount; ++i)
+					{
+						if (activeTargets == null || !activeTargets.TryGetValue(types[i], out targetList) || 0 == (targetCount = targetList.Length))
+						{
+							simpleTargets[i] = new GeneratorTarget[] { new GeneratorTarget(types[i], null, null) };
+						}
+						else
+						{
+							simpleTargets[i] = targetList;
+							instanceCount *= targetCount;
+						}
+					}
+
+					// Do combinatorics to get all instances
+					int[] indices = new int[typeCount];
+					int currentType = 0;
+					int lastType = typeCount - 1;
+					int nextInstance = 0;
+					retVal = new GeneratorTarget[instanceCount][];
+					for (; true;)
+					{
+						int currentIndex = indices[currentType];
+						if (currentIndex < simpleTargets[currentType].Length)
+						{
+							if (currentType == lastType)
+							{
+								// At the end, create and populate a new instance off the indices
+								GeneratorTarget[] instance = new GeneratorTarget[typeCount];
+								retVal[nextInstance] = instance;
+								++nextInstance;
+								for (int i = 0; i < typeCount; ++i)
+								{
+									instance[i] = simpleTargets[i][indices[i]];
+								}
+								++indices[currentType];
+							}
+							else
+							{
+								++currentType;
+							}
+						}
+						else if (currentType == 0)
+						{
+							// Nothing left to do, can't back out any more
+							break;
+						}
+						else
+						{
+							indices[currentType] = 0; // Start over on this row
+							++indices[--currentType]; // Return to previous row and bump up one
+						}
+					}
+				}
+				return retVal;
+			}
+#endregion // Instance expansion
+#region Equality routines
+			/// <summary>
+			/// Strongly typed Equals override
+			/// </summary>
+			public bool Equals(GeneratorTargetSet obj)
+			{
+				if ((object)obj == null)
+				{
+					return false;
+				}
+
+				IList<string> typeNames;
+				IList<string> otherTypeNames;
+				if (object.ReferenceEquals(this, obj) || object.ReferenceEquals(typeNames = myTargetTypes, otherTypeNames = obj.myTargetTypes))
+				{
+					return true;
+				}
+
+				int count = typeNames.Count;
+				if (otherTypeNames.Count == count)
+				{
+					for (int i = 0; i < count; ++i)
+					{
+						if (typeNames[i] != otherTypeNames[i])
+						{
+							return false;
+						}
+					}
+					return true;
+				}
+				return false;
+			}
+			/// <summary>
+			/// Standard Equals override
+			/// </summary>
+			public override bool Equals(object obj)
+			{
+				GeneratorTargetSet other = obj as GeneratorTargetSet;
+				return (object)other != null && Equals(other);
+			}
+			/// <summary>
+			/// Standard GetHashCode override
+			/// </summary>
+			public override int GetHashCode()
+			{
+				return Utility.GetCombinedHashCode<string>(myTargetTypes);
+			}
+			/// <summary>
+			/// Equality operator
+			/// </summary>
+			public static bool operator ==(GeneratorTargetSet left, GeneratorTargetSet right)
+			{
+				if ((object)left == null)
+				{
+					return (object)right == null;
+				}
+				else if ((object)right == null)
+				{
+					return false;
+				}
+				return left.Equals(right);
+			}
+			/// <summary>
+			/// Inequality operator
+			/// </summary>
+			public static bool operator !=(GeneratorTargetSet left, GeneratorTargetSet right)
+			{
+				if ((object)left == null)
+				{
+					return (object)right != null;
+				}
+				else if ((object)right == null)
+				{
+					return true;
+				}
+				return !left.Equals(right);
+			}
+#endregion // Equality routines
+		}
 		/// <summary>
 		/// Get an extension property directly from <see cref="M:EnvDTE.Document.Object"/>
 		/// with a direct query to <see cref="EnvDTE.IExtensibleObject"/> as a backup.
@@ -1111,6 +1986,8 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 #endif // VISUALSTUDIO_10_0
 			return retVal as T;
 		}
+
+		public delegate void NameValuePairCallback(string name, string value);
 #if VISUALSTUDIO_10_0
 		/// <summary>
 		/// Replacement for BuildItem method
@@ -1166,7 +2043,149 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 			// ItemGroup key should probably be Include, not EvaluatedInclude.
 			return item.Include;
 		}
+		/// <summary>
+		/// Get matching metavalue names and values
+		/// </summary>
+		/// <param name="item">The item to iterate</param>
+		/// <param name="nameFilter">A filter for the metadata names.</param>
+		/// <param name="callback">Callback for the matching name/value pairs.</param>
+		public static void GetMatchingMetadata(ProjectItemElement item, Predicate<string> nameFilter, NameValuePairCallback callback)
+		{
+			foreach (ProjectMetadataElement metadataElement in item.Metadata)
+			{
+				string name = metadataElement.Name;
+				if (nameFilter(name))
+				{
+					callback(name, metadataElement.Value);
+				}
+			}
+		}
+		/// <summary>
+		/// Set metadata on a build item for a given metadata key and value
+		/// </summary>
+		public static void SetItemMetaData(ProjectItemElement buildItem, string metadataName, string metadataValue)
+		{
+			// ProjectItemElement.SetMetadata adds a new metadata element with the same name
+			// as the previous one. There is no 'RemoveMetadata' that takes a string, so we go through
+			// the entire metadata collection and clean it out.
+			foreach (ProjectMetadataElement element in buildItem.Metadata)
+			{
+				if (element.Name == metadataName)
+				{
+					// The Metadata collection is a read-only snapshot, so deleting from it is safe
+					// inside the iterator.
+					buildItem.RemoveChild(element);
+					// Do not break. This handles removing multiple metadata items with the
+					// same name, which will clean up project files affected by this problem
+					// in previous drops.
+				}
+			}
+			ProjectMetadataElement newElement = buildItem.AddMetadata(metadataName, metadataValue);
+		}
+		/// <summary>
+		/// Remove a metadata item
+		/// </summary>
+		public static void RemoveItemMetaData(ProjectItemElement buildItem, string metadataName)
+		{
+			foreach (ProjectMetadataElement element in buildItem.Metadata)
+			{
+				if (element.Name == metadataName)
+				{
+					// The Metadata collection is a read-only snapshot, so deleting from it is safe
+					// inside the iterator.
+					buildItem.RemoveChild(element);
+					break;
+				}
+			}
+		}
+		/// <summary>
+		/// New items have been added to the item group tracking this orm file. Adding
+		/// items to the project creates the side effiect of also adding each of these items
+		/// to another item group in the project. Remove these items from the tracked list of
+		/// side effect names, presented
+		/// </summary>
+		public static void RemoveSideEffectItems(IDictionary<string, string> sideEffectItemNames, ProjectRootElement project, ProjectItemGroupElement ignoreItemGroup)
+		{
+			if (sideEffectItemNames == null || sideEffectItemNames.Count == 0)
+			{
+				return;
+			}
+
+			string skipCondition = ignoreItemGroup.Condition.Trim();
+			List<ProjectItemElement> removeItems = new List<ProjectItemElement>();
+			foreach (ProjectItemGroupElement group in project.ItemGroups)
+			{
+				if (group.Condition.Trim() == skipCondition)
+				{
+					continue;
+				}
+
+				foreach (ProjectItemElement item in group.Items)
+				{
+					if (sideEffectItemNames.ContainsKey(item.Include))
+					{
+						removeItems.Add(item);
+					}
+				}
+			}
+
+			foreach (ProjectItemElement item in removeItems)
+			{
+				ProjectElementContainer removeFrom;
+				if (null != (removeFrom = item.Parent))
+				{
+					removeFrom.RemoveChild(item);
+
+					// Remove the container if it is empty. Note that
+					// this happens automatically in the old build system.
+					ProjectItemGroupElement groupElement;
+					if (null != (groupElement = removeFrom as ProjectItemGroupElement) &&
+						groupElement.Items.Count == 0 &&
+						null != (removeFrom = groupElement.Parent))
+					{
+						removeFrom.RemoveChild(groupElement);
+					}
+				}
+			}
+		}
 #else // VISUALSTUDIO_10_0
+		/// <summary>
+		/// New items have been added to the item group tracking this orm file. Adding
+		/// items to the project creates the side effiect of also adding each of these items
+		/// to another item group in the project. Remove these items from the tracked list of
+		/// side effect names, presented
+		/// </summary>
+		public static void RemoveSideEffectItems(IDictionary<string, string> sideEffectItemNames, Project project, BuildItemGroup ignoreItemGroup)
+		{
+			if (sideEffectItemNames == null || sideEffectItemNames.Count == 0)
+			{
+				return;
+			}
+
+			string skipCondition = ignoreItemGroup.Condition.Trim();
+
+			List<BuildItem> removeItems = new List<BuildItem>();
+			foreach (BuildItemGroup group in project.ItemGroups)
+			{
+				if (group.Condition.Trim() == skipCondition)
+				{
+					continue;
+				}
+
+				foreach (BuildItem item in group)
+				{
+					if (sideEffectItemNames.ContainsKey(item.Include))
+					{
+						removeItems.Add(item);
+					}
+				}
+			}
+
+			foreach (BuildItem item in removeItems)
+			{
+				project.RemoveItem(item);
+			}
+		}
 		/// <summary>
 		/// Replacement for BuildItem.FinalItemSpec property
 		/// </summary>
@@ -1174,7 +2193,437 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 		{
 			return item.FinalItemSpec;
 		}
+		/// <summary>
+		/// Get matching metavalue names and values
+		/// </summary>
+		/// <param name="item">The item to iterate</param>
+		/// <param name="nameFilter">A filter for the metadata names.</param>
+		/// <param name="callback">Callback for the matching name/value pairs.</param>
+		public static void GetMatchingMetadata(BuildItem item, Predicate<string> nameFilter, NameValuePairCallback callback)
+		{
+			foreach (object name in item.MetadataNames)
+			{
+				string nameString = name as string;
+				if (nameString != null && nameFilter(nameString))
+				{
+					callback(nameString, item.GetEvaluatedMetadata(nameString);
+				}
+			}
+		}
+		/// <summary>
+		/// Remove a metadata item
+		/// </summary>
+		public static void RemoveItemMetaData(BuildItem buildItem, string metadataName)
+		{
+			if (buildItem.HasMetadata(metadataName))
+			{
+				buildItem.RemoveMetadata(metadataName);
+			}
+		}
+		/// <summary>
+		/// Set metadata on a build item for a given metadata key and value
+		/// </summary>
+		public static void SetItemMetaData(BuildItem buildItem, string metadataName, string metadataValue)
+		{
+			buildItem.SetMetadata(metadataName, metadataValue);
+		}
 #endif // VISUALSTUDIO_10_0
+		/// <summary>
+		/// Get the primary generator name from a non-normalized name string that
+		/// may include both primary and secondary names.
+		/// </summary>
+		/// <param name="rawNameData">The raw name data. This may be a space delimited
+		/// list, but no space normalization is expected.</param>
+		/// <returns>The first name from the list, or <see langword="null"/> if no name is specified.</returns>
+		public static string GetPrimaryGeneratorName(string rawNameData)
+		{
+			if (string.IsNullOrEmpty(rawNameData))
+			{
+				return null;
+			}
+			if (rawNameData.IndexOf(' ') == -1)
+			{
+				return rawNameData;
+			}
+			else if (!string.IsNullOrEmpty(rawNameData = rawNameData.Trim()))
+			{
+				int spaceIndex;
+				return (-1 == (spaceIndex = rawNameData.IndexOf(' '))) ? rawNameData : rawNameData.Substring(0, spaceIndex);
+			}
+			return null;
+		}
+		/// <summary>
+		/// GeneratorTarget providers may not distinguish between null and empty values, but this tool
+		/// uses a null TargetName values to indicate a placeholder target. This also gets rid of empty lists.
+		/// </summary>
+		/// <remarks>A placeholder is defined for each target type when a format used by an active generator
+		/// does not have any generator targets. This not only allows a file to be created--possibly with minimal
+		/// content indicating how the extension corresponding to that generator actually creates GeneratorTarget
+		/// elements--it also allows the generator to be selected in the custom tool before the targets
+		/// are created in the project.</remarks>
+		public static void NormalizeGeneratorTargets(IDictionary<string, GeneratorTarget[]> targets)
+		{
+			if (targets != null)
+			{
+				List<string> removeEmptyKeys = null;
+				foreach (KeyValuePair<string, GeneratorTarget[]> kvp in targets)
+				{
+					GeneratorTarget[] targetList = kvp.Value;
+					if (targetList == null || targetList.Length == 0)
+					{
+						(removeEmptyKeys ?? (removeEmptyKeys = new List<string>())).Add(kvp.Key);
+					}
+					else
+					{
+						for (int i = 0; i < targetList.Length; ++i)
+						{
+							GeneratorTarget target = targetList[i];
+							if (target.TargetName == null)
+							{
+								targetList[i] = new GeneratorTarget(target.TargetType, string.Empty, target.TargetId);
+							}
+						}
+					}
+				}
+
+				if (removeEmptyKeys != null)
+				{
+					for (int i = 0, count = removeEmptyKeys.Count; i < count; ++i)
+					{
+						targets.Remove(removeEmptyKeys[i]);
+					}
+				}
+			}
+		}
+		/// <summary>
+		/// Create a generator target set (without identifiers) using the storaged metadata on a build item.
+		/// </summary>
+		/// <param name="item">The item to iterate.</param>
+		/// <returns>An instance if GeneratorTarget data is available.</returns>
+#if VISUALSTUDIO_10_0
+		public static GeneratorTarget[] GeneratorTargetsFromBuildItem(ProjectItemElement item)
+#else // VISUALSTUDIO_10_0
+		public static GeneratorTarget[] GeneratorTargetsFromBuildItem(BuildItem item)
+#endif // VISUALSTUDIO_10_0
+		{
+			// Preliminary, determine which items are placeholders. Placeholders are still named as attributes
+			// to preserve numbering, but they are given a null value instead of an empty value for the GeneratorTarget
+			string[] placeholders = null;
+			GetMatchingMetadata(
+				item,
+				delegate(string test)
+				{
+					return test == ITEMMETADATA_ORMGENERATORTARGET_PLACEHOLDERS;
+				},
+				delegate (string name, string value)
+				{
+					if (!string.IsNullOrEmpty(value))
+					{
+						placeholders = value.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+						if (placeholders != null && placeholders.Length == 0)
+						{
+							placeholders = null;
+						}
+					}
+				}
+				);
+
+			// First pass, get an item count. These are stored as 1-based indexes, so the highest number is the count.
+			// There is no guarantee that this matches currently registered generator targets, we're simply extracting text.
+			int max = 0;
+			GetMatchingMetadata(
+				item,
+				delegate (string test)
+				{
+					return test.StartsWith(ITEMMETADATA_ORMGENERATORTARGET_PREFIX);
+				},
+				delegate (string name, string value)
+				{
+					int searchStart = ITEMMETADATA_ORMGENERATORTARGET_PREFIX.Length;
+					int secondDelimiter = name.IndexOf('_', searchStart);
+					int testIndex;
+					if (secondDelimiter != -1 && int.TryParse(name.Substring(searchStart, secondDelimiter - searchStart), out testIndex) && testIndex > max)
+					{
+						max = testIndex;
+					}
+				});
+
+			// Second pass, populate the generator set
+			if (max != 0)
+			{
+				GeneratorTarget[] retVal = new GeneratorTarget[max];
+				GetMatchingMetadata(
+					item,
+					delegate (string test)
+					{
+						return test.StartsWith(ITEMMETADATA_ORMGENERATORTARGET_PREFIX);
+					},
+					delegate (string name, string value)
+					{
+						int searchStart = ITEMMETADATA_ORMGENERATORTARGET_PREFIX.Length;
+						int secondDelimiter = name.IndexOf('_', searchStart);
+						int testIndex;
+						if (secondDelimiter != -1 && int.TryParse(name.Substring(searchStart, secondDelimiter - searchStart), out testIndex) && testIndex > 0)
+						{
+							string targetType = name.Substring(secondDelimiter + 1);
+							retVal[--testIndex] = new GeneratorTarget(targetType, (placeholders == null || Array.IndexOf<string>(placeholders, targetType) == -1) ? value ?? string.Empty : null, null);
+						}
+					});
+
+				for (int i = 0; i < max; ++i)
+				{
+					if (retVal[i] == null)
+					{
+						// Sanity check, not well formed
+						return null;
+					}
+				}
+				return retVal;
+			}
+			return null;
+		}
+		/// <summary>
+		/// Create a generator target set (without identifiers) using the stored metadata on a build item.
+		/// </summary>
+		/// <param name="item">The item to iterate.</param>
+		/// <param name="targetInstance">The generator target values.</param>
+#if VISUALSTUDIO_10_0
+		public static void SetGeneratorTargetMetadata(ProjectItemElement item, GeneratorTarget[] targetInstance)
+#else // VISUALSTUDIO_10_0
+		public static void SetGeneratorTargetMetadata(BuildItem item, GeneratorTarget[] targetInstance)
+#endif // VISUALSTUDIO_10_0
+		{
+			List<string> placeholders = null;
+			for (int i = 0, count = targetInstance.Length; i < count; ++i)
+			{
+				GeneratorTarget target = targetInstance[i];
+				string type = target.TargetType;
+				string name = target.TargetName;
+				if (name == null)
+				{
+					(placeholders ?? (placeholders = new List<string>())).Add(type);
+					name = string.Empty;
+				}
+				item.SetMetadata(ITEMMETADATA_ORMGENERATORTARGET_PREFIX + (i + 1).ToString() + "_" + type, name);
+			}
+			if (placeholders != null)
+			{
+				item.SetMetadata(ITEMMETADATA_ORMGENERATORTARGET_PLACEHOLDERS, placeholders.Count == 1 ? placeholders[0] : string.Join<string>(" ", placeholders));
+			}
+		}
+
+		/// <summary>
+		/// Items with generator target placeholders have the same signature as items
+		/// without placeholders and empty name fields. Both of these are valid combinations and
+		/// produce the same file name and signature. This means that an item can switch back and
+		/// forth from placeholder to non-placeholder status.
+		/// </summary>
+		/// <param name="item">The item to update.</param>
+		/// <param name="targetInstance">Instance to update. The target item will already match the signature for this instance.</param>
+#if VISUALSTUDIO_10_0
+		public static void UpdateGeneratorTargetPlaceholders(ProjectItemElement item, GeneratorTarget[] targetInstance)
+#else // VISUALSTUDIO_10_0
+		public static void UpdateGeneratorTargetPlaceholders(BuildItem item, GeneratorTarget[] targetInstance)
+#endif // VISUALSTUDIO_10_0
+		{
+			List<string> placeholders = null;
+			for (int i = 0, count = targetInstance.Length; i < count; ++i)
+			{
+				GeneratorTarget target = targetInstance[i];
+				string name = target.TargetName;
+				if (name == null)
+				{
+					(placeholders ?? (placeholders = new List<string>())).Add(target.TargetType);
+				}
+			}
+
+			if (placeholders == null)
+			{
+				// Make sure the placeholders item is removed
+				RemoveItemMetaData(item, ITEMMETADATA_ORMGENERATORTARGET_PLACEHOLDERS);
+			}
+			else
+			{
+				// Update or add item
+				SetItemMetaData(item, ITEMMETADATA_ORMGENERATORTARGET_PLACEHOLDERS, placeholders.Count == 1 ? placeholders[0] : string.Join(" ", placeholders));
+			}
+		}
+
+		private static List<string> EmptyStringList = new List<string>();
+#pragma warning disable CS1587
+		/// <summary>
+		/// Get generator targets by output format.
+		/// </summary>
+		/// <param name="generatorNamesByOutputFormat">Dictionary mapping an output format to a specific generator.</param>
+		/// <param name="activeTargets">Generator targets retrieved from the active model.</param>
+#if VISUALSTUDIO_15_0
+		/// <param name="serviceProvider"></param>
+#endif
+		/// <returns>Target sets keyed by format name. Each target set represents a list of target types used by the format, with
+		/// instances pulled from different target combinations.</returns>
+		/// <remarks>Generators are not directly tied to an output format. They are
+		/// tied to a specific generator that creates that output format. This mapping
+		/// is determined before this call.
+		/// If the target types used by a generator do not have an entry in <paramref name="activeTargets"/>
+		/// then placeholder elements (with a null TargetName) are created for the target types used by the
+		/// selected generators.</remarks>
+		public static IDictionary<string, GeneratorTargetSet> ExpandGeneratorTargets(IDictionary<string, string> generatorNamesByOutputFormat, IDictionary<string, GeneratorTarget[]> activeTargets
+#if VISUALSTUDIO_15_0
+			, IServiceProvider serviceProvider
+#endif
+			)
+#pragma warning restore CS1587
+		{
+			// Filter the generator targets by those actually specified in the project.
+			// Target type order is determined by the specified target order and the
+			// specified dependency formats, with the source input format given
+			// priority over the dependent formats.
+			IDictionary<string, IORMGenerator> generatorsByName =
+#if VISUALSTUDIO_15_0
+				ORMCustomTool.GetORMGenerators(serviceProvider);
+#else
+				ORMCustomTool.ORMGenerators;
+#endif
+			Dictionary<string, List<string>> orderedTargetsByOutputFormat = new Dictionary<string, List<string>>();
+			foreach (string generatorName in generatorNamesByOutputFormat.Values)
+			{
+				GetExpandedGeneratorTargets(generatorsByName[generatorName], generatorsByName, generatorNamesByOutputFormat, orderedTargetsByOutputFormat);
+			}
+
+			Dictionary<string, GeneratorTargetSet> targetSetsByOutputFormat = null;
+			Dictionary<GeneratorTargetSet, GeneratorTargetSet> targetSets = null;
+			foreach (KeyValuePair<string, List<string>> pair in orderedTargetsByOutputFormat)
+			{
+				List<string> targets = pair.Value;
+				if (targets == EmptyStringList)
+				{
+					continue;
+				}
+				string outputFormat = pair.Key;
+				GeneratorTargetSet targetSet = new GeneratorTargetSet(targets);
+
+				if (targetSetsByOutputFormat == null)
+				{
+					targetSetsByOutputFormat = new Dictionary<string, GeneratorTargetSet>();
+					targetSets = new Dictionary<GeneratorTargetSet, GeneratorTargetSet>();
+				}
+
+				GeneratorTargetSet existingTargetSet;
+				if (targetSets.TryGetValue(targetSet, out existingTargetSet))
+				{
+					targetSet = existingTargetSet;
+				}
+				else
+				{
+					targetSet.Instances = targetSet.PopulateInstances(activeTargets);
+				}
+				targetSetsByOutputFormat[outputFormat] = targetSet;
+			}
+			return targetSetsByOutputFormat;
+		}
+		private static List<string> GetExpandedGeneratorTargets(
+			IORMGenerator generator,
+			IDictionary<string, IORMGenerator> generatorsByName,
+			IDictionary<string, string> generatorNamesByOutputFormat,
+			Dictionary<string, List<string>> orderedTargetsByOutputFormat)
+		{
+			string outputFormat = generator.ProvidesOutputFormat;
+			List<string> existingTargets;
+			if (orderedTargetsByOutputFormat.TryGetValue(outputFormat, out existingTargets))
+			{
+				// Do a basic recursion check
+				if (existingTargets == null)
+				{
+					throw new InvalidOperationException("Generators have cyclic dependencies."); // UNDONE: Localize error (should never happen to an end user, but might happen to an extension developer)
+				}
+				return existingTargets == EmptyStringList ? null : existingTargets;
+			}
+			// Guard against recursion, will replace later by real data
+			orderedTargetsByOutputFormat[outputFormat] = null;
+			List<string> targets = null;
+			int totalInputTargetCount = 0;
+			foreach (string requiredInputFormat in generator.RequiresInputFormats)
+			{
+				IList<string> inputTargets;
+				string generatorName;
+				IORMGenerator inputGenerator;
+				if (generatorNamesByOutputFormat.TryGetValue(requiredInputFormat, out generatorName) &&
+					generatorsByName.TryGetValue(generatorName, out inputGenerator) &&
+					null != (inputTargets = GetExpandedGeneratorTargets(
+						inputGenerator,
+						generatorsByName,
+						generatorNamesByOutputFormat,
+						orderedTargetsByOutputFormat)) &&
+					inputTargets != EmptyStringList)
+				{
+					// Copy unique items into the list. Make sure we don't have duplication--
+					// if two inputs have the same target type then we treat it as a single branch
+					// with the name decoration happening on the first item.
+					if (totalInputTargetCount == 0)
+					{
+						targets = new List<string>(inputTargets);
+						totalInputTargetCount = targets.Count;
+					}
+					else
+					{
+						int inputTargetCount = inputTargets.Count;
+						for (int i = 0; i < inputTargetCount; ++i)
+						{
+							string inputTargetType = inputTargets[i];
+							int j = 0;
+							for (; j < totalInputTargetCount; ++j)
+							{
+								if (inputTargetType == targets[j])
+								{
+									break;
+								}
+							}
+							if (j == totalInputTargetCount)
+							{
+								targets.Add(inputTargetType);
+								// Don't increment the target count until we're through this list,
+								// which we already know is unique.
+							}
+						}
+						totalInputTargetCount = targets.Count;
+					}
+				}
+			}
+			IList<string> targetTypes = generator.GeneratorTargetTypes;
+			if (targetTypes != null &&
+				targetTypes.Count != 0)
+			{
+				foreach (string targetType in targetTypes)
+				{
+					if (targets == null)
+					{
+						targets = new List<string>();
+						targets.Add(targetType);
+					}
+					else
+					{
+						int i = 0;
+						for (; i < totalInputTargetCount; ++i)
+						{
+							if (targetType == targets[i])
+							{
+								break;
+							}
+						}
+						if (i == totalInputTargetCount)
+						{
+							targets.Add(targetType);
+						}
+					}
+				}
+			}
+			if (targets == null)
+			{
+				targets = EmptyStringList; // Use a non-null value to facilitate recursion tracking
+			}
+			orderedTargetsByOutputFormat[outputFormat] = targets;
+			return targets;
+		}
 	}
 #endregion // ORMCustomToolUtility class
 }

--- a/Tools/ORMCustomTool/ORMCustomTool.csproj
+++ b/Tools/ORMCustomTool/ORMCustomTool.csproj
@@ -66,6 +66,25 @@
     <Reference Include="Microsoft.VisualStudio.Shell.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <SpecificVersion>False</SpecificVersion>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Condition=" $(TargetVisualStudioNumericVersion) &gt;= 9.0 " Include="Microsoft.VisualStudio.Shell.Interop.9.0, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Condition=" $(TargetVisualStudioNumericVersion) &gt;= 10.0 " Include="Microsoft.VisualStudio.Shell.Interop.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Condition=" $(TargetVisualStudioNumericVersion) &gt;= 11.0 " Include="Microsoft.VisualStudio.Shell.Interop.11.0, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Condition=" $(TargetVisualStudioNumericVersion) &gt;= 12.0 " Include="Microsoft.VisualStudio.Shell.Interop.12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Modeling.Sdk.Shell$(TargetDslToolsVersionSuffix), Version=$(TargetDslToolsAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <SpecificVersion>False</SpecificVersion>
     </Reference>

--- a/Tools/ORMCustomTool/ORMCustomTool.csproj
+++ b/Tools/ORMCustomTool/ORMCustomTool.csproj
@@ -82,6 +82,11 @@
     <Reference Include="VSLangProj, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <SpecificVersion>False</SpecificVersion>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Modeling.Sdk$(TargetDslToolsVersionSuffix), Version=$(TargetDslToolsAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="ORMSolutions.ORMArchitect.Core.$(TargetVisualStudioShortProductName), Version=1.0.0.0, Culture=neutral, PublicKeyToken=$(NORMAPublicKeyToken), processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\ORMModel\$(OutDir)\ORMSolutions.ORMArchitect.Core.$(TargetVisualStudioShortProductName).dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ORMExtensionManager.cs" />

--- a/Tools/ORMCustomTool/UI/BranchPartition.cs
+++ b/Tools/ORMCustomTool/UI/BranchPartition.cs
@@ -19,17 +19,33 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 			private int myStart;
 			private int myCount;
 			private string myHeader;
+			private bool myDeemphasizedHeader;
 			/// <summary>
-			/// Create a new partition section
+			/// Create a new partition section with no header.
 			/// </summary>
 			/// <param name="start">The starting index in the inner branch</param>
 			/// <param name="count">The number of items in the inner branch to include in this branch.</param>
-			/// <param name="header">A header string for this group of items. It the header is not null, then this item will expand to a branch and have a length of 1.</param>
-			public BranchPartitionSection(int start, int count, string header)
+			public BranchPartitionSection(int start, int count)
+			{
+				myStart = start;
+				myCount = count;
+				myHeader = null;
+				myDeemphasizedHeader = false;
+			}
+			/// <summary>
+			/// Create a new partition section with a header. This section
+			/// will have one item in it and expand to a branch.
+			/// </summary>
+			/// <param name="start">The starting index in the inner branch</param>
+			/// <param name="count">The number of items in the inner branch to include in this branch.</param>
+			/// <param name="header">A header string for this group of items.</param>
+			/// <param name="deemphasizeHeader">Set to <see langword="true"/> to deemphasize (gray out) the header.</param>
+			public BranchPartitionSection(int start, int count, string header, bool deemphasizeHeader)
 			{
 				myStart = start;
 				myCount = count;
 				myHeader = header;
+				myDeemphasizedHeader = deemphasizeHeader;
 			}
 			/// <summary>
 			/// The starting index in the inner branch
@@ -59,6 +75,16 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 				get
 				{
 					return myHeader;
+				}
+			}
+			/// <summary>
+			/// Deemphasize the header for this section
+			/// </summary>
+			public bool DeemphasizeHeader
+			{
+				get
+				{
+					return myDeemphasizedHeader;
 				}
 			}
 			public int VisibleItemCount
@@ -194,7 +220,10 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 				if (row == -1)
 				{
 					VirtualTreeDisplayData displayData = VirtualTreeDisplayData.Empty;
-					displayData.GrayText = true;
+					if (section.DeemphasizeHeader)
+					{
+						displayData.GrayText = true;
+					}
 					return displayData;
 				}
 				return myInnerBranch.GetDisplayData(row, column, requiredData);
@@ -208,7 +237,7 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 					if (style == ObjectStyle.ExpandedBranch)
 					{
 						options = 0;
-						return new BranchPartition(myInnerBranch, myIndexer, new BranchPartitionSection(section.Start, section.Count, null));
+						return new BranchPartition(myInnerBranch, myIndexer, new BranchPartitionSection(section.Start, section.Count));
 					}
 					return null;
 				}

--- a/Tools/ORMCustomTool/UI/ORMGeneratorSelectionControl.cs
+++ b/Tools/ORMCustomTool/UI/ORMGeneratorSelectionControl.cs
@@ -129,7 +129,7 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 		private readonly ProjectRootElement _project;
 		private readonly ProjectItemGroupElement _originalItemGroup;
 #else // VISUALSTUDIO_10_0
-		private readonly Project _project;
+		private readonly Microsoft.Build.BuildEngine.Project _project;
 		private readonly BuildItemGroup _originalItemGroup;
 #endif // VISUALSTUDIO_10_0
 		private readonly Dictionary<string, PseudoBuildItem> _pseudoItemsByOutputFormat;
@@ -148,7 +148,7 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 			ProjectRootElement project = ProjectRootElement.TryOpen(projectItem.ContainingProject.FullName);
 			string projectFullPath = project.FullPath;
 #else // VISUALSTUDIO_10_0
-			Project project = Engine.GlobalEngine.GetLoadedProject(projectItem.ContainingProject.FullName);
+			Microsoft.Build.BuildEngine.Project project = Engine.GlobalEngine.GetLoadedProject(projectItem.ContainingProject.FullName);
 			string projectFullPath = project.FullFileName;
 #endif // VISUALSTUDIO_10_0
 			_project = project;
@@ -358,6 +358,9 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 			}
 		}
 
+#if !VISUALSTUDIO_10_0
+		private delegate void Action<T1, T2, T3, T4>(T1 t1, T2 t2, T3 t3, T4 t4);
+#endif
 		protected override void OnClosed(EventArgs e)
 		{
 			if (_savedChanges)
@@ -403,7 +406,7 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 				ProjectRootElement project = _project;
 #else // VISUALSTUDIO_10_0
 				BuildItemGroup itemGroup = _originalItemGroup;
-				Project project = _project;
+				Microsoft.Build.BuildEngine.Project project = _project;
 #endif // VISUALSTUDIO_10_0
 				EnvDTE.ProjectItem projectItem = _projectItem;
 				string sourceFileName = _sourceFileName;
@@ -460,7 +463,7 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 						}
 
 						// Temporarily load the document so that the generator targets can be resolved.
-						using (Store store = new ModelLoader(ORMDesignerPackage.ExtensionLoader, true).Load(projectItem.FileNames[0]))
+						using (Store store = new ModelLoader(ORMDesignerPackage.ExtensionLoader, true).Load(projectItem.get_FileNames(0)))
 						{
 							docTargets = GeneratorTarget.ConsolidateGeneratorTargets(store as IFrameworkServices);
 						}

--- a/Tools/ORMCustomTool/UI/ORMGeneratorSelectionControl.cs
+++ b/Tools/ORMCustomTool/UI/ORMGeneratorSelectionControl.cs
@@ -20,11 +20,19 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
 using System.Text;
 using System.Windows.Forms;
+using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.VirtualTreeGrid;
+using ORMSolutions.ORMArchitect.Framework;
+using ORMSolutions.ORMArchitect.Core.Load;
+using ORMSolutions.ORMArchitect.Core.Shell;
+using Microsoft.VisualStudio.Modeling;
+using EnvDTE;
 #if VISUALSTUDIO_10_0
 using Microsoft.Build.Construction;
+using Microsoft.Win32;
 #else
 using Microsoft.Build.BuildEngine;
 #endif
@@ -39,25 +47,92 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 		private const string ITEMMETADATA_DEPENDENTUPON = "DependentUpon";
 		private const string ITEMMETADATA_GENERATOR = "Generator";
 		private const string ITEMMETADATA_ORMGENERATOR = "ORMGenerator";
+		private const string ITEMMETADATA_ORMGENERATORTARGET_PREFIX = "ORMGeneratorTarget_"; // Suffix is index then _ then the target type, value is the name (not the id)
+
+		/// <summary>
+		/// A component class for <see cref="PseudoBuildItem"/> to represent a
+		/// single build item. A PseudoBuildItem is a placeholder for a single
+		/// output format, which can be comprised of multiple instances dependending
+		/// on how the generator targets resolve.
+		/// </summary>
+		private class PseudoBuildInstance
+		{
+			public readonly string OriginalGeneratorNames;
+			public readonly GeneratorTarget[] OriginalGeneratorTargets;
+
+			/// <summary>
+			/// Flag during final processing if the instance is removed.
+			/// </summary>
+			/// <remarks>clearing PseudoBuiltItem.CurrentGeneratorNames indicates
+			/// that all instances for the build item are to be removed, so this is
+			/// used to manage individual instances.</remarks>
+			public bool IsRemoved;
+
+			/// <summary>
+			/// Create an instance corresponding to a single generated
+			/// output to associated with a <see cref="PseudoBuildItem"/>
+			/// </summary>
+			/// <param name="originalGeneratorNames"></param>
+			/// <param name="originalGeneratorTargets"></param>
+			public PseudoBuildInstance(string originalGeneratorNames, GeneratorTarget[] originalGeneratorTargets)
+			{
+				OriginalGeneratorNames = originalGeneratorNames;
+				OriginalGeneratorTargets = originalGeneratorTargets;
+				IsRemoved = false;
+			}
+		}
+
+		/// <summary>
+		/// Create a structure to represent a virtual build item. The dialog
+		/// is keyed off of generator types, which originally mapped to a single
+		/// build item in the current group in this system. However, generator
+		/// targets now allow multiple build items per group. We don't want to
+		/// radically complicate the dialog by adding additional dimensions showing
+		/// the different generator targets, so we pretend that all build items
+		/// with the same generator are the same item, then expand this back out
+		/// to real build items on commit.
+		/// </summary>
+		/// <remarks>We may split this up in the future with different generators
+		/// and different format modifiers applying to different branches, but it is
+		/// not worth the complication at this point.</remarks>
+		private class PseudoBuildItem
+		{
+			public string DefaultGeneratedFileName;
+			public string CurrentGeneratorNames;
+			public List<PseudoBuildInstance> OriginalInstances;
+
+			/// <summary>
+			/// Create an initial instance of a pseudo build item for an existing item.
+			/// </summary>
+			public PseudoBuildItem(string currentGeneratorNames, string defaultGeneratedFileName)
+			{
+				CurrentGeneratorNames = currentGeneratorNames;
+				DefaultGeneratedFileName = defaultGeneratedFileName;
+			}
+
+			/// <summary>
+			/// Add a tracked target set found in the original items.
+			/// </summary>
+			public void AddOriginalInstance(string generatorNames, GeneratorTarget[] generatorTargets)
+			{
+				(OriginalInstances ?? (OriginalInstances = new List<PseudoBuildInstance>())).Add(new PseudoBuildInstance(generatorNames, generatorTargets));
+			}
+		}
 
 		private readonly MainBranch _mainBranch;
 		private readonly EnvDTE.ProjectItem _projectItem;
 		private bool _savedChanges;
 		private readonly string _sourceFileName;
-		private Dictionary<string, string> _removedItems;
 		private readonly string _projectItemRelativePath;
 		private readonly IServiceProvider _serviceProvider;
 #if VISUALSTUDIO_10_0
 		private readonly ProjectRootElement _project;
 		private readonly ProjectItemGroupElement _originalItemGroup;
-		private readonly ProjectItemGroupElement _itemGroup;
-		private readonly Dictionary<string, ProjectItemElement> _itemsByGenerator;
 #else // VISUALSTUDIO_10_0
 		private readonly Project _project;
 		private readonly BuildItemGroup _originalItemGroup;
-		private readonly BuildItemGroup _itemGroup;
-		private readonly Dictionary<string, BuildItem> _itemsByGenerator;
 #endif // VISUALSTUDIO_10_0
+		private readonly Dictionary<string, PseudoBuildItem> _pseudoItemsByOutputFormat;
 		private ORMGeneratorSelectionControl()
 		{
 			this.InitializeComponent();
@@ -84,53 +159,13 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 
 #if VISUALSTUDIO_10_0
 			ProjectItemGroupElement originalItemGroup = ORMCustomTool.GetItemGroup(project, projectItemRelativePath);
-			ProjectItemGroupElement itemGroup;
-			if (originalItemGroup == null)
-			{
-				itemGroup = project.AddItemGroup();
-				itemGroup.Condition = string.Concat(ITEMGROUP_CONDITIONSTART, projectItemRelativePath, ITEMGROUP_CONDITIONEND);
-			}
-			else
-			{
-				itemGroup = project.AddItemGroup();
-				itemGroup.Condition = originalItemGroup.Condition;
-				foreach (ProjectItemElement item in originalItemGroup.Items)
-				{
-					ProjectItemElement newItem = itemGroup.AddItem(item.ItemType, item.Include);
-					newItem.Condition = item.Condition;
-					foreach (ProjectMetadataElement metadataElement in item.Metadata)
-					{
-						newItem.AddMetadata(metadataElement.Name, metadataElement.Value);
-					}
-				}
-			}
 #else // VISUALSTUDIO_10_0
 			BuildItemGroup originalItemGroup = ORMCustomTool.GetItemGroup(project, projectItemRelativePath);
-			BuildItemGroup itemGroup;
-			if (originalItemGroup == null)
-			{
-				itemGroup = project.AddNewItemGroup();
-				itemGroup.Condition = string.Concat(ITEMGROUP_CONDITIONSTART, projectItemRelativePath, ITEMGROUP_CONDITIONEND);
-			}
-			else
-			{
-				itemGroup = project.AddNewItemGroup();
-				itemGroup.Condition = originalItemGroup.Condition;
-				foreach (BuildItem item in originalItemGroup)
-				{
-					BuildItem newItem = itemGroup.AddNewItem(item.Name, item.Include, false);
-					newItem.Condition = item.Condition;
-					item.CopyCustomMetadataTo(newItem);
-				}
-			}
 #endif // VISUALSTUDIO_10_0
 			_originalItemGroup = originalItemGroup;
-			_itemGroup = itemGroup;
 
-			string condition = itemGroup.Condition.Trim();
-
-			string sourceFileName = this._sourceFileName = projectItem.Name;
-
+			string sourceFileName = projectItem.Name;
+			_sourceFileName = sourceFileName;
 			this.textBox_ORMFileName.Text = sourceFileName;
 
 			this.button_SaveChanges.Click += new EventHandler(this.SaveChanges);
@@ -183,58 +218,80 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 			tree.Root = (lastPrimary == -1) ? (IBranch)mainBranch : new BranchPartition(
 				mainBranch,
 				primaryIndices,
-				new BranchPartitionSection(0, lastPrimary + 1, null),
-				new BranchPartitionSection(totalCount - modifierCount, modifierCount, "Generated File Modifiers"),
-				new BranchPartitionSection(lastPrimary + 1, totalCount - lastPrimary - modifierCount - 1, "Intermediate and Secondary Files")); // UNDONE: Localize Header
+				new BranchPartitionSection(0, lastPrimary + 1),
+				new BranchPartitionSection(totalCount - modifierCount, modifierCount, "Generated File Modifiers", false),
+				new BranchPartitionSection(lastPrimary + 1, totalCount - lastPrimary - modifierCount - 1, "Intermediate and Secondary Files", true)); // UNDONE: Localize Header
 			this.virtualTreeControl.ShowToolTips = true;
 			this.virtualTreeControl.FullCellSelect = true;
 
-#if VISUALSTUDIO_10_0
-			Dictionary<string, ProjectItemElement> buildItemsByGenerator = this._itemsByGenerator = new Dictionary<string, ProjectItemElement>(itemGroup.Count, StringComparer.OrdinalIgnoreCase);
-			foreach (ProjectItemElement buildItem in itemGroup.Items)
-#else // VISUALSTUDIO_10_0
-			Dictionary<string, BuildItem> buildItemsByGenerator = this._itemsByGenerator = new Dictionary<string, BuildItem>(itemGroup.Count, StringComparer.OrdinalIgnoreCase);
-			foreach (BuildItem buildItem in itemGroup)
-#endif // VISUALSTUDIO_10_0
-			{
-				// Do this very defensively so that the dialog can still be opened if a project is out
-				// of step with the generators registered on a specific machine.
-				string generatorNameData = buildItem.GetEvaluatedMetadata(ITEMMETADATA_ORMGENERATOR);
-				string[] generatorNames; // The first string is the primary generator, others are the format modifiers
-				int generatorNameCount;
-				IORMGenerator primaryGenerator;
-				MainBranch.OutputFormatBranch primaryFormatBranch;
-				if (!String.IsNullOrEmpty(generatorNameData) &&
-					String.Equals(buildItem.GetEvaluatedMetadata(ITEMMETADATA_DEPENDENTUPON), sourceFileName, StringComparison.OrdinalIgnoreCase) &&
-					null != (generatorNames = generatorNameData.Split((char[])null, StringSplitOptions.RemoveEmptyEntries)) &&
-					0 != (generatorNameCount = generatorNames.Length) &&
+			Dictionary<string, PseudoBuildItem> pseudoItemsByOutputFormat = new Dictionary<string, PseudoBuildItem>(StringComparer.OrdinalIgnoreCase);
+			_pseudoItemsByOutputFormat = pseudoItemsByOutputFormat;
+			IDictionary<string, IORMGenerator> generators = 
 #if VISUALSTUDIO_15_0
-					ORMCustomTool.GetORMGenerators(serviceProvider)
+				ORMCustomTool.GetORMGenerators(serviceProvider);
 #else
-					ORMCustomTool.ORMGenerators
+				ORMCustomTool.ORMGenerators;
 #endif
-						.TryGetValue(generatorNames[0], out primaryGenerator) &&
-					mainBranch.Branches.TryGetValue(primaryGenerator.ProvidesOutputFormat, out primaryFormatBranch))
+			if (originalItemGroup != null)
+			{
+#if VISUALSTUDIO_10_0
+				foreach (ProjectItemElement buildItem in originalItemGroup.Items)
+#else // VISUALSTUDIO_10_0
+				foreach (BuildItem buildItem in originalItemGroup)
+#endif // VISUALSTUDIO_10_0
 				{
-					System.Diagnostics.Debug.Assert(primaryFormatBranch.SelectedORMGenerator == null);
-					primaryFormatBranch.SelectedORMGenerator = primaryGenerator;
-					buildItemsByGenerator.Add(generatorNames[0], buildItem);
-
-					// Format modifiers are attached to the end of the list
-					for (int i = 1; i < generatorNameCount; ++i )
+					// Do this very defensively so that the dialog can still be opened if a project is out
+					// of step with the generators registered on a specific machine.
+					string generatorNameData;
+					string[] generatorNames; // The first string is the primary generator, others are the format modifiers
+					int generatorNameCount;
+					IORMGenerator primaryGenerator;
+					MainBranch.OutputFormatBranch primaryFormatBranch;
+					if (!string.IsNullOrEmpty(generatorNameData = buildItem.GetEvaluatedMetadata(ITEMMETADATA_ORMGENERATOR)) &&
+						!string.IsNullOrEmpty(generatorNameData = generatorNameData.Trim()) &&
+						string.Equals(buildItem.GetEvaluatedMetadata(ITEMMETADATA_DEPENDENTUPON), sourceFileName, StringComparison.OrdinalIgnoreCase) &&
+						null != (generatorNames = generatorNameData.Split((char[])null, StringSplitOptions.RemoveEmptyEntries)) &&
+						0 != (generatorNameCount = generatorNames.Length) &&
+						// This assumes that each generator target of the same type has all of the same options.
+						// This is currently the result of this dialog, and we're not considering hand edits
+						// to the project file at this point.
+						generators.TryGetValue(generatorNames[0], out primaryGenerator) &&
+						mainBranch.Branches.TryGetValue(primaryGenerator.ProvidesOutputFormat, out primaryFormatBranch))
 					{
-						MainBranch.OutputFormatBranch modifierBranch = primaryFormatBranch.NextModifier;
-						string findName = generatorNames[i];
-						while (modifierBranch != null)
+						PseudoBuildItem pseudoItem;
+						string outputFormat = primaryGenerator.ProvidesOutputFormat;
+
+						if (!pseudoItemsByOutputFormat.TryGetValue(outputFormat, out pseudoItem))
 						{
-							IORMGenerator testGenerator = modifierBranch.ORMGenerators[0];
-							if (testGenerator.OfficialName == findName)
+							// Note that we can't use the build item file name here as it might be decorated with
+							// target names. Go back to the generator to get an undecorated default name.
+							pseudoItem = new PseudoBuildItem(generatorNameData, primaryGenerator.GetOutputFileDefaultName(sourceFileName));
+							pseudoItemsByOutputFormat.Add(outputFormat, pseudoItem);
+
+							if (primaryFormatBranch.SelectedORMGenerator == null)
 							{
-								modifierBranch.SelectedORMGenerator = testGenerator;
-								break;
+								primaryFormatBranch.SelectedORMGenerator = primaryGenerator;
 							}
-							modifierBranch = modifierBranch.NextModifier;
+
+							// Format modifiers are attached to the end of the list
+							for (int i = 1; i < generatorNameCount; ++i)
+							{
+								MainBranch.OutputFormatBranch modifierBranch = primaryFormatBranch.NextModifier;
+								string findName = generatorNames[i];
+								while (modifierBranch != null)
+								{
+									IORMGenerator testGenerator = modifierBranch.ORMGenerators[0];
+									if (testGenerator.OfficialName == findName)
+									{
+										modifierBranch.SelectedORMGenerator = testGenerator;
+										break;
+									}
+									modifierBranch = modifierBranch.NextModifier;
+								}
+							}
 						}
+
+						pseudoItem.AddOriginalInstance(generatorNameData, ORMCustomToolUtility.GeneratorTargetsFromBuildItem(buildItem));
 					}
 				}
 			}
@@ -248,48 +305,57 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 			}
 		}
 
-#if VISUALSTUDIO_10_0
-		private IDictionary<string, ProjectItemElement> BuildItemsByGenerator
-#else
-		private IDictionary<string, BuildItem> BuildItemsByGenerator
-#endif
+		private IDictionary<string, PseudoBuildItem> PseudoItemsByOutputFormat
 		{
 			get
 			{
-				return this._itemsByGenerator;
+				return this._pseudoItemsByOutputFormat;
 			}
 		}
 
-#if VISUALSTUDIO_10_0
-		private void RemoveRemovedItem(ProjectItemElement buildItem)
-#else
-		private void RemoveRemovedItem(BuildItem buildItem)
-#endif
+		private void RemovePseudoItem(string outputFormat)
 		{
-			if (_removedItems != null)
+			Dictionary<string, PseudoBuildItem> items = _pseudoItemsByOutputFormat;
+			PseudoBuildItem pseudoItem;
+			if (items.TryGetValue(outputFormat, out pseudoItem))
 			{
-				string key = ORMCustomToolUtility.GetItemInclude(buildItem);
-				if (_removedItems.ContainsKey(key))
+				if (pseudoItem.OriginalInstances != null)
 				{
-					_removedItems.Remove(key);
+					// Indicate an original item is deleted by clearing the generator names.
+					pseudoItem.CurrentGeneratorNames = null;
+				}
+				else
+				{
+					// Added and removed in the same session, no reason to track.
+					items.Remove(outputFormat);
 				}
 			}
 		}
 
-#if VISUALSTUDIO_10_0
-		private void AddRemovedItem(ProjectItemElement buildItem)
-#else
-		private void AddRemovedItem(BuildItem buildItem)
-#endif
+		/// <summary>
+		/// Add a new item, or resurrect a deleted one.
+		/// </summary>
+		/// <param name="generator">The generator to add.</param>
+		/// <param name="currentGeneratorNames">The current generator names. Note that if this is a
+		/// toggle that adds a new generator for the same format, then the current names may
+		/// include format modifiers that are not available from the generator itself.</param>
+		private void AddPseudoItem(IORMGenerator generator, string currentGeneratorNames)
 		{
-			Dictionary<string, string> items = _removedItems;
-			if (items == null)
+			Dictionary<string, PseudoBuildItem> items = _pseudoItemsByOutputFormat;
+			string outputFormat = generator.ProvidesOutputFormat;
+			string generatedFileName = generator.GetOutputFileDefaultName(_sourceFileName);
+			PseudoBuildItem pseudoItem;
+			if (items.TryGetValue(outputFormat, out pseudoItem))
 			{
-				items = new Dictionary<string, string>();
-				_removedItems = items;
+				pseudoItem.CurrentGeneratorNames = currentGeneratorNames;
+				pseudoItem.DefaultGeneratedFileName = generatedFileName;
 			}
-			string key = ORMCustomToolUtility.GetItemInclude(buildItem);
-			items[key] = key;
+			else
+			{
+				pseudoItem = new PseudoBuildItem(null, generatedFileName);
+				pseudoItem.CurrentGeneratorNames = currentGeneratorNames;
+				items[outputFormat] = pseudoItem;
+			}
 		}
 
 		protected override void OnClosed(EventArgs e)
@@ -332,67 +398,319 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 			}
 			if (_savedChanges)
 			{
-				// Delete the removed items from the project
-				if (_removedItems != null)
+#if VISUALSTUDIO_10_0
+				ProjectItemGroupElement itemGroup = _originalItemGroup;
+				ProjectRootElement project = _project;
+#else // VISUALSTUDIO_10_0
+				BuildItemGroup itemGroup = _originalItemGroup;
+				Project project = _project;
+#endif // VISUALSTUDIO_10_0
+				EnvDTE.ProjectItem projectItem = _projectItem;
+				string sourceFileName = _sourceFileName;
+				Dictionary<string, PseudoBuildItem>pseudoItems = _pseudoItemsByOutputFormat;
+				IDictionary<string, IORMGenerator> generators =
+#if VISUALSTUDIO_15_0
+					ORMCustomTool.GetORMGenerators(_serviceProvider);
+#else
+					ORMCustomTool.ORMGenerators;
+#endif
+				PseudoBuildItem pseudoItem;
+				string generatorNameData; // The first string is the primary generator, others are the format modifiers, space delimited
+				IVsShell shell;
+
+				Dictionary<string, IORMGenerator> generatorsWithTargetsByOutputFormat = null;
+				IDictionary<string, ORMCustomToolUtility.GeneratorTargetSet> targetSetsByFormatName = null;
+				foreach (PseudoBuildItem testPseudoItem in pseudoItems.Values)
 				{
-					EnvDTE.ProjectItems subItems = _projectItem.ProjectItems;
-					foreach (string itemName in _removedItems.Keys)
+					string primaryGeneratorName;
+					IList<string> generatorTargets;
+					IORMGenerator generator;
+					if (!string.IsNullOrEmpty(generatorNameData = testPseudoItem.CurrentGeneratorNames) &&
+						null != (primaryGeneratorName = ORMCustomToolUtility.GetPrimaryGeneratorName(generatorNameData)) &&
+						generators.TryGetValue(primaryGeneratorName, out generator) &&
+						null != (generatorTargets = generator.GeneratorTargetTypes) &&
+						0 != generatorTargets.Count)
 					{
-						try
-						{
-							EnvDTE.ProjectItem subItem = subItems.Item(itemName);
-							if (subItem != null)
-							{
-								subItem.Delete();
-							}
-						}
-						catch (ArgumentException)
-						{
-							// Swallow
-						}
+						(generatorsWithTargetsByOutputFormat ?? (generatorsWithTargetsByOutputFormat = new Dictionary<string, IORMGenerator>(StringComparer.OrdinalIgnoreCase)))[generator.ProvidesOutputFormat] = generator;
 					}
 				}
-				// throw away the original build item group
-				if (_originalItemGroup != null)
+				if (generatorsWithTargetsByOutputFormat != null)
 				{
-					try
+					IDictionary<string, GeneratorTarget[]> docTargets = null;
+					EnvDTE.Document projectItemDocument = projectItem.Document;
+					string itemPath;
+					if (projectItemDocument != null)
 					{
-#if VISUALSTUDIO_10_0
-						_project.RemoveChild(_originalItemGroup);
-#else
-						_project.RemoveItemGroup(_originalItemGroup);
-#endif
+						using (Stream targetsStream = ORMCustomToolUtility.GetDocumentExtension<Stream>(projectItemDocument, "ORMGeneratorTargets", itemPath = projectItem.get_FileNames(0), _serviceProvider))
+						{
+							if (targetsStream != null)
+							{
+								targetsStream.Seek(0, SeekOrigin.Begin);
+								docTargets = new BinaryFormatter().Deserialize(targetsStream) as IDictionary<string, GeneratorTarget[]>;
+							}
+						}
 					}
-					catch (InvalidOperationException)
+					else if (null != (shell = _serviceProvider.GetService(typeof(SVsShell)) as IVsShell))
 					{
-						// Swallow
+						Guid pkgId = typeof(ORMDesignerPackage).GUID;
+						IVsPackage package;
+						if (0 != shell.IsPackageLoaded(ref pkgId, out package) || package == null)
+						{
+							shell.LoadPackage(ref pkgId, out package);
+						}
+
+						// Temporarily load the document so that the generator targets can be resolved.
+						using (Store store = new ModelLoader(ORMDesignerPackage.ExtensionLoader, true).Load(projectItem.FileNames[0]))
+						{
+							docTargets = GeneratorTarget.ConsolidateGeneratorTargets(store as IFrameworkServices);
+						}
+					}
+
+					// We have generators that care about targets, which means that ExpandGeneratorTargets will
+					// product placeholder targets for these generators even if docTargets is currently null.
+					// This allows the dialog to turn on a generator before the data (or even extension) to feed
+					// it is available in the model and provides a smooth transition in and out of this placeholder
+					// state. It is up to the individual generators to proceed without explicit target data or
+					// to produce a message for the user with instructions on how to add the data to the model.
+					Dictionary<string, string> generatorNamesByOutputFormat = new Dictionary<string, string>();
+					foreach (KeyValuePair<string, PseudoBuildItem> pair in pseudoItems)
+					{
+						generatorNameData = pair.Value.CurrentGeneratorNames;
+						if (!string.IsNullOrEmpty(generatorNameData))
+						{
+							generatorNamesByOutputFormat[pair.Key] = ORMCustomToolUtility.GetPrimaryGeneratorName(generatorNameData);
+						}
+					}
+					targetSetsByFormatName = ORMCustomToolUtility.ExpandGeneratorTargets(generatorNamesByOutputFormat, docTargets
+#if VISUALSTUDIO_15_0
+						, _serviceProvider
+#endif // VISUALSTUDIO_15_0
+						);
+				}
+
+				Dictionary<string, BitTracker> processedGeneratorTargets = null;
+				if (targetSetsByFormatName != null)
+				{
+					processedGeneratorTargets = new Dictionary<string, BitTracker>();
+					foreach (KeyValuePair<string, ORMCustomToolUtility.GeneratorTargetSet> kvp in targetSetsByFormatName)
+					{
+						processedGeneratorTargets[kvp.Key] = new BitTracker(kvp.Value.Instances.Length);
 					}
 				}
 
+				if (null != itemGroup)
+				{
 #if VISUALSTUDIO_10_0
-				Dictionary<string, ProjectItemElement> removeItems = new Dictionary<string, ProjectItemElement>();
-#else
-				Dictionary<string, BuildItem> removeItems = new Dictionary<string, BuildItem>();
+					Dictionary<string, ProjectItemElement> removedItems = null;
+					foreach (ProjectItemElement item in itemGroup.Items)
+#else // VISUALSTUDIO_10_0
+					Dictionary<string, BuildItem> removedItems = null;
+					foreach (BuildItem item in itemGroup)
+#endif // VISUALSTUDIO_10_0
+					{
+						string primaryGeneratorName;
+						string outputFormat;
+						IORMGenerator generator;
+						if (null != (primaryGeneratorName = ORMCustomToolUtility.GetPrimaryGeneratorName(item.GetEvaluatedMetadata(ITEMMETADATA_ORMGENERATOR))) &&
+							string.Equals(item.GetEvaluatedMetadata(ITEMMETADATA_DEPENDENTUPON), sourceFileName, StringComparison.OrdinalIgnoreCase) &&
+							generators.TryGetValue(primaryGeneratorName, out generator) &&
+							pseudoItems.TryGetValue(outputFormat = generator.ProvidesOutputFormat, out pseudoItem))
+						{
+							generatorNameData = pseudoItem.CurrentGeneratorNames;
+							ORMCustomToolUtility.GeneratorTargetSet targetSet = null;
+							BitTracker processedForFormat = default(BitTracker);
+							if (targetSetsByFormatName != null)
+							{
+								if (targetSetsByFormatName.TryGetValue(outputFormat, out targetSet))
+								{
+									processedForFormat = processedGeneratorTargets[outputFormat];
+								}
+							}
+
+							List<PseudoBuildInstance> originalInstances;
+							bool removeInstance = false;
+							if (string.IsNullOrEmpty(generatorNameData))
+							{
+								// The item is deleted, mark for removal
+								removeInstance = true;
+							}
+							else if (null != (originalInstances = pseudoItem.OriginalInstances))
+							{
+								for (int i = 0, count = originalInstances.Count; i < count && !removeInstance; ++i)
+								{
+									PseudoBuildInstance instance = originalInstances[i];
+									if (instance.IsRemoved)
+									{
+										continue;
+									}
+
+									GeneratorTarget[] targets = instance.OriginalGeneratorTargets;
+									if (targetSet != null)
+									{
+										if (targets == null)
+										{
+											// Remove, if a target set is available then it must be used
+											removeInstance = true;
+										}
+										else
+										{
+											int instanceIndex = targetSet.IndexOfInstance(targets, delegate (int ignoreInstance) { return processedForFormat[ignoreInstance]; });
+											if (instanceIndex == -1)
+											{
+												removeInstance = true;
+											}
+											else if (!processedForFormat[instanceIndex])
+											{
+												if (instance.OriginalGeneratorNames != generatorNameData)
+												{
+													// This is a preexisting item, update its meta information
+													ORMCustomToolUtility.SetItemMetaData(item, ITEMMETADATA_ORMGENERATOR, generatorNameData);
+												}
+												processedForFormat[instanceIndex] = true;
+												processedGeneratorTargets[outputFormat] = processedForFormat;
+												break;
+											}
+										}
+									}
+									else if (targets != null)
+									{
+										// Remove, formatter changed to one that does not use a generator target
+										removeInstance = true;
+									}
+									else if (instance.OriginalGeneratorNames != generatorNameData)
+									{
+										// This is a preexisting item, update its meta information
+										ORMCustomToolUtility.SetItemMetaData(item, ITEMMETADATA_ORMGENERATOR, generatorNameData);
+									}
+
+									if (removeInstance)
+									{
+										instance.IsRemoved = true;
+									}
+								}
+							}
+
+							if (removeInstance)
+							{
+								if (removedItems == null)
+								{
+#if VISUALSTUDIO_10_0
+									removedItems = new Dictionary<string, ProjectItemElement>();
+#else // VISUALSTUDIO_10_0
+									removedItems = new Dictionary<string, BuildItem>();
+#endif // VISUALSTUDIO_10_0
+								}
+								removedItems[ORMCustomToolUtility.GetItemInclude(item)] = item;
+							}
+						}
+					}
+					if (removedItems != null)
+					{
+						EnvDTE.ProjectItems subItems = projectItem.ProjectItems;
+#if VISUALSTUDIO_10_0
+						foreach (KeyValuePair<string, ProjectItemElement> removePair in removedItems)
+						{
+							ProjectItemElement removeItem = removePair.Value;
+							ProjectElementContainer removeFrom;
+							if (null != (removeFrom = removeItem.Parent))
+							{
+								removeFrom.RemoveChild(removeItem);
+							}
+#else // VISUALSTUDIO_10_0
+						foreach (KeyValuePair<string, BuildItem> removePair in removedItems)
+						{
+							project.RemoveItem(removePair.Value);
+#endif // VISUALSTUDIO_10_0
+							try
+							{
+								EnvDTE.ProjectItem subItem = subItems.Item(removePair.Key);
+								if (subItem != null)
+								{
+									subItem.Delete();
+								}
+							}
+							catch (ArgumentException)
+							{
+								// Swallow
+							}
+						}
+					}
+
+#if !VISUALSTUDIO_10_0
+					// Empty item groups remove themselves from the project, we'll need
+					// to recreate below if the group is empty after the remove phase.
+					if (itemGroup.Count == 0)
+					{
+						itemGroup = null;
+					}
 #endif
+				}
+
+				// Removes and changes are complete, proceed with adds for any new items
+				string newItemDirectory = null;
+				string projectPath = null;
+				EnvDTE.ProjectItems projectItems = null;
 				string tmpFile = null;
+				// Adding a file to our special item group adds it to the build system. However,
+				// it does not add it to the parallel project system, which is what displays in
+				// the solution explorer. Therefore, we also explicitly add the item to the
+				// project system as well. Unfortunately, this extra add automatically creates
+				// a redundant item (usually in a new item group) for our adding item. Track anything
+				// we add through the project system so that we can remove these redundant items from the
+				// build system when we're done.
+				Dictionary<string, string> sideEffectItemNames = null;
 				try
 				{
-					EnvDTE.ProjectItems projectItems = _projectItem.ProjectItems;
-#if VISUALSTUDIO_10_0
-					string itemDirectory = (new FileInfo((string)_project.FullPath)).DirectoryName;
-					foreach (ProjectItemElement item in _itemGroup.Items)
-#else
-					string itemDirectory = (new FileInfo((string)_project.FullFileName)).DirectoryName;
-					foreach (BuildItem item in this._itemGroup)
-#endif
+					Action<IORMGenerator, string, ORMCustomToolUtility.GeneratorTargetSet, GeneratorTarget[]> addProjectItem = delegate (IORMGenerator generator, string allGenerators, ORMCustomToolUtility.GeneratorTargetSet targetSet, GeneratorTarget[] targetInstance)
 					{
-						string filePath = string.Concat(itemDirectory, Path.DirectorySeparatorChar, item.Include);
-						string fileName = (new FileInfo(item.Include)).Name;
-						if (File.Exists(filePath))
+						if (itemGroup == null)
+						{
+#if VISUALSTUDIO_10_0
+							itemGroup = project.AddItemGroup();
+#else
+							itemGroup = project.AddNewItemGroup();
+#endif
+							itemGroup.Condition = string.Concat(ITEMGROUP_CONDITIONSTART, _projectItemRelativePath, ITEMGROUP_CONDITIONEND);
+						}
+						if (newItemDirectory == null)
+						{
+							// Initialize general information
+#if VISUALSTUDIO_10_0
+							projectPath = project.FullPath;
+#else
+							projectPath = project.FullFileName;
+#endif
+							newItemDirectory = Path.GetDirectoryName(new Uri(projectPath).MakeRelativeUri(new Uri((string)projectItem.Properties.Item("LocalPath").Value)).ToString());
+							projectItems = projectItem.ProjectItems;
+						}
+
+						string defaultFileName = generator.GetOutputFileDefaultName(sourceFileName);
+						string fileName = targetInstance == null ? defaultFileName : ORMCustomToolUtility.GeneratorTargetSet.DecorateFileName(defaultFileName, targetInstance);
+						string fileRelativePath = Path.Combine(newItemDirectory, fileName);
+						string fileAbsolutePath = string.Concat(new FileInfo(projectPath).DirectoryName, Path.DirectorySeparatorChar, fileRelativePath);
+#if VISUALSTUDIO_10_0
+						ProjectItemElement newBuildItem;
+#else
+						BuildItem newBuildItem;
+#endif
+						newBuildItem = generator.AddGeneratedFileItem(itemGroup, sourceFileName, fileRelativePath);
+
+						if (allGenerators != null)
+						{
+							ORMCustomToolUtility.SetItemMetaData(newBuildItem, ITEMMETADATA_ORMGENERATOR, allGenerators);
+						}
+
+						if (targetInstance != null)
+						{
+							ORMCustomToolUtility.SetGeneratorTargetMetadata(newBuildItem, targetInstance);
+						}
+
+						(sideEffectItemNames ?? (sideEffectItemNames = new Dictionary<string, string>()))[fileRelativePath] = null;
+						if (File.Exists(fileAbsolutePath))
 						{
 							try
 							{
-								projectItems.AddFromFile(filePath);
+								projectItems.AddFromFile(fileAbsolutePath);
 							}
 							catch (ArgumentException)
 							{
@@ -405,14 +723,71 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 							{
 								tmpFile = Path.GetTempFileName();
 							}
-							EnvDTE.ProjectItem projectItem = projectItems.AddFromTemplate(tmpFile, fileName);
-							string customTool = item.GetMetadata(ITEMMETADATA_GENERATOR);
-							if (!string.IsNullOrEmpty(customTool))
+							EnvDTE.ProjectItem newProjectItem = projectItems.AddFromTemplate(tmpFile, fileName);
+							string customTool;
+							if (!string.IsNullOrEmpty(customTool = newBuildItem.GetMetadata(ITEMMETADATA_GENERATOR)))
 							{
-								projectItem.Properties.Item("CustomTool").Value = customTool;
+								newProjectItem.Properties.Item("CustomTool").Value = customTool;
 							}
 						}
-						removeItems[item.Include] = null;
+					};
+
+					foreach (KeyValuePair<string, PseudoBuildItem> keyedPseudoItem in pseudoItems)
+					{
+						pseudoItem = keyedPseudoItem.Value;
+						string allGenerators = pseudoItem.CurrentGeneratorNames;
+						string primaryGenerator = ORMCustomToolUtility.GetPrimaryGeneratorName(allGenerators);
+						if (allGenerators == primaryGenerator)
+						{
+							allGenerators = null;
+						}
+						IORMGenerator generator = generators[primaryGenerator];
+						string outputFormat = generator.ProvidesOutputFormat;
+						ORMCustomToolUtility.GeneratorTargetSet targetSet = null;
+						if (targetSetsByFormatName != null)
+						{
+							targetSetsByFormatName.TryGetValue(outputFormat, out targetSet);
+						}
+
+						if (targetSet != null)
+						{
+							// OriginalInstances were already updated in the remove loop and processed
+							// instances were flagged. Find additional instances from the target set (created
+							// just now from the current model), not from the pseudoItem (created from the project
+							// files that possibly reflect a previous version of the model).
+							GeneratorTarget[][] instances = targetSet.Instances;
+							BitTracker processed = processedGeneratorTargets[outputFormat];
+
+							for (int i = 0, count = instances.Length; i < count; ++i)
+							{
+								if (!processed[i])
+								{
+									addProjectItem(generator, allGenerators, targetSet, instances[i]);
+								}
+							}
+						}
+						else if (pseudoItem.OriginalInstances == null)
+						{
+							addProjectItem(generator, allGenerators, null, null);
+						}
+						else
+						{
+							// Make sure there was an original instance that did not have a target set.
+							List<PseudoBuildInstance> originals = pseudoItem.OriginalInstances;
+							int i = 0, count = originals.Count;
+							for (; i < count; ++i)
+							{
+								if (originals[i].OriginalGeneratorTargets == null)
+								{
+									break;
+								}
+							}
+
+							if (i == count)
+							{
+								addProjectItem(generator, allGenerators, null, null);
+							}
+						}
 					}
 				}
 				finally
@@ -423,60 +798,25 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 					}
 				}
 
-#if VISUALSTUDIO_10_0
-				foreach (ProjectItemGroupElement group in this._project.ItemGroups)
-#else
-				foreach (BuildItemGroup group in this._project.ItemGroups)
-#endif
+				if (sideEffectItemNames != null)
 				{
-					if (group.Condition.Trim() == this._itemGroup.Condition.Trim())
-					{
-						continue;
-					}
-#if VISUALSTUDIO_10_0
-					foreach (ProjectItemElement item in group.Items)
-#else
-					foreach (BuildItem item in group)
-#endif
-					{
-						if (removeItems.ContainsKey(item.Include))
-						{
-							removeItems[item.Include] = item;
-						}
-					}
-				}
-				foreach (string key in removeItems.Keys)
-				{
-#if VISUALSTUDIO_10_0
-					ProjectItemElement removeItem;
-					ProjectElementContainer removeFrom;
-					if (null != (removeItem =removeItems[key]) &&
-						null != (removeFrom = removeItem.Parent))
-					{
-						removeFrom.RemoveChild(removeItem);
-					}
-#else
-					BuildItem removeItem = removeItems[key];
-					if (removeItem != null)
-					{
-						_project.RemoveItem(removeItem);
-					}
-#endif
+					ORMCustomToolUtility.RemoveSideEffectItems(sideEffectItemNames, project, itemGroup);
 				}
 
-				VSLangProj.VSProjectItem vsProjectItem = _projectItem.Object as VSLangProj.VSProjectItem;
+#if VISUALSTUDIO_10_0
+				// Old group remove themselves when empty, but this is
+				// not true in the new build system. Clean up as needed.
+				if (itemGroup != null &&
+					itemGroup.Items.Count == 0)
+				{
+					project.RemoveChild(itemGroup);
+				}
+#endif
+				VSLangProj.VSProjectItem vsProjectItem = projectItem.Object as VSLangProj.VSProjectItem;
 				if (vsProjectItem != null)
 				{
 					vsProjectItem.RunCustomTool();
 				}
-			}
-			else
-			{
-#if VISUALSTUDIO_10_0
-				_project.RemoveChild(_itemGroup);
-#else
-				_project.RemoveItemGroup(_itemGroup);
-#endif
 			}
 			base.OnClosed(e);
 		}

--- a/Tools/ORMCustomTool/XslORMGenerator.cs
+++ b/Tools/ORMCustomTool/XslORMGenerator.cs
@@ -461,7 +461,13 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 
 					if (placeholders != null)
 					{
-						argumentList.AddParam("_GeneratorPlaceholders", string.Empty, placeholders.Count == 1 ? placeholders[0] : string.Join(" ", placeholders));
+						argumentList.AddParam("_GeneratorPlaceholders", string.Empty, placeholders.Count == 1 ? placeholders[0] :
+#if VISUALSTUDIO_10_0
+							string.Join<string>(" ", placeholders)
+#else
+							string.Join(" ", placeholders.ToArray())
+#endif
+						);
 					}
 				}
 

--- a/Tools/ORMCustomTool/XslORMGenerator.cs
+++ b/Tools/ORMCustomTool/XslORMGenerator.cs
@@ -27,6 +27,7 @@ using System.Xml.Xsl;
 using Microsoft.Win32;
 
 using Debug = System.Diagnostics.Debug;
+using ORMSolutions.ORMArchitect.Framework;
 
 #if VISUALSTUDIO_10_0
 using Microsoft.Build.Construction;
@@ -82,6 +83,8 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 				Debug.Assert(sourceInputFormat != null);
 				string[] referenceInputFormats = generatorKey.GetValue("ReferenceInputFormats", EmptyStringArray) as string[];
 				string[] companionOutputFormats = generatorKey.GetValue("CompanionOutputFormats", EmptyStringArray) as string[];
+				string[] generatorTargetTypes = generatorKey.GetValue("GeneratorTargetTypes", EmptyStringArray) as string[];
+				string[] generatorTargetInstructions = generatorKey.GetValue("GeneratorTargetInstructions", EmptyStringArray) as string[];
 
 				List<string> requiresInputFormats;
 
@@ -115,6 +118,21 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 				this._requiredExtensions = extensions;
 				this._requiresInputFormats = new ReadOnlyCollection<string>(requiresInputFormats);
 				this._companionOutputFormats = Array.AsReadOnly<string>(companionOutputFormats);
+				this._generatorTargetTypes = Array.AsReadOnly<string>(generatorTargetTypes);
+
+				if (generatorTargetTypes.Length != 0)
+				{
+					string[] instructions = new string[generatorTargetTypes.Length];
+					for (int i = 0; i < generatorTargetTypes.Length; ++i)
+					{
+						instructions[i] = generatorKey.GetValue("GeneratorTargetInstruction_" + generatorTargetTypes[i], null) as string;
+					}
+					this._generatorTargetInstructions = Array.AsReadOnly<string>(instructions);
+				}
+				else
+				{
+					this._generatorTargetInstructions = EmptyStringArray;
+				}
 
 				this._transform = new XslCompiledTransform(System.Diagnostics.Debugger.IsAttached);
 				string transformLocation = generatorKey.GetValue("TransformUri", null) as string;
@@ -310,6 +328,18 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 				get { return this._companionOutputFormats; }
 			}
 
+			private readonly IList<string> _generatorTargetTypes;
+			public IList<string> GeneratorTargetTypes
+			{
+				get { return this._generatorTargetTypes; }
+			}
+
+			private readonly IList<string> _generatorTargetInstructions;
+			public IList<string> GeneratorTargetInstructions
+			{
+				get { return this._generatorTargetInstructions; }
+			}
+
 			private readonly string _fileExtension;
 			public string GetOutputFileDefaultName(string sourceFileName)
 			{
@@ -372,12 +402,13 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 				BuildItem buildItem,
 #endif
 				Stream outputStream,
-				IDictionary<string, Stream> inputFormatStreams,
+				GetFormatStream inputFormatStreams,
 				string defaultNamespace,
-				IORMGeneratorItemProperties itemProperties)
+				IORMGeneratorItemProperties itemProperties,
+				GeneratorTarget[] targetInstance)
 			{
 				this.EnsureTransform();
-				Stream inputStream = inputFormatStreams[this._sourceInputFormat];
+				Stream inputStream = inputFormatStreams(this._sourceInputFormat);
 				
 				XsltArgumentList argumentList = new XsltArgumentList();
 				argumentList.AddParam("DefaultNamespace", string.Empty, defaultNamespace);
@@ -386,15 +417,51 @@ namespace ORMSolutions.ORMArchitect.ORMCustomTool
 				string[] referenceFormats = this._referenceInputFormats;
 				if (referenceFormats != null)
 				{
-					for (int i = 0; i < referenceFormats.Length; i++)
+					for (int i = 0; i < referenceFormats.Length; ++i)
 					{
 						string referenceFormat = referenceFormats[i];
-						Stream referenceStream = inputFormatStreams[referenceFormat];
+						Stream referenceStream = inputFormatStreams(referenceFormat);
 						using (XmlReader referenceReader = XmlReader.Create(referenceStream))
 						{
 							argumentList.AddParam(referenceFormat, string.Empty, new XPathDocument(referenceReader).CreateNavigator().Select(DocumentElementXPathExpression));
 						}
 						referenceStream.Seek(0, SeekOrigin.Begin);
+					}
+				}
+
+				if (targetInstance != null)
+				{
+					List<string> placeholders = null;
+					for (int i = 0; i < targetInstance.Length; ++i)
+					{
+						GeneratorTarget target = targetInstance[i];
+						string targetType = target.TargetType;
+						string instructionText = null;
+						bool isLocalPlaceholder = false;
+						if (target.TargetName == null)
+						{
+							(placeholders ?? (placeholders = new List<string>())).Add(targetType);
+							IList<string> localTargetTypes = _generatorTargetTypes;
+							int targetTypeCount;
+							if (0 != (targetTypeCount = localTargetTypes.Count))
+							{
+								for (int j = 0; j < targetTypeCount; ++j)
+								{
+									if (targetType == localTargetTypes[j])
+									{
+										isLocalPlaceholder = true;
+										instructionText = _generatorTargetInstructions[j];
+										break;
+									}
+								}
+							}
+						}
+						argumentList.AddParam(targetType, string.Empty, target.TargetId ?? (isLocalPlaceholder ? instructionText : null) ?? string.Empty);
+					}
+
+					if (placeholders != null)
+					{
+						argumentList.AddParam("_GeneratorPlaceholders", string.Empty, placeholders.Count == 1 ? placeholders[0] : string.Join(" ", placeholders));
 					}
 				}
 


### PR DESCRIPTION
Add the notion of 'Generator Target' to enable generation of multiple
files of the same type based on inputs from the current model. This is
a major enhancement from the prior one-file-per-output-format approach
and is designed for advanced model partitioning where a single file of
a given type cannot accurately represent the output. Doing this
successfully requires dynamic input from the model extensions, which
means that the ORM model must be loaded for code generation if a
generator signals support for generator targets.

The generator registers the GeneratorTargetTypes value (REG_MULTI_SZ)
indicating the target types that are needed to generate multiple files.
An extension domain model implements the IGeneratorTargetProvider to
provide GeneratorTarget (TargetType, TargetName, TargetId) elements to
the generation layer. Here the name is a file part and the id is passed
in a TargetType parameter to the transform. TargetTypes should not
overlap file format names as these are also passed to the transform.
Note that this means that running the custom tool can actually change
the output files whereas previously the set of output files was not
dependent in any way on the model contents.

In addition to the GeneratorTargetTypes registry values a generator
can also add GeneratorTargetInstruction_TYPE for each of the registered
target types. This allows generator-specific instructions to be sent
to the generator transforms. If there is no model-provided data
specifying the generator target we still generate a single file of that
type by sending modified parameters to the generator transform. The
_GeneratorPlaceholders parameter is added with a space-delimited list
of each of the target type names that do not have data provided by the
model. In this case if an instruction is registered it will be passed
in the corresponding target type parameter, which would otherwise be
empty. This mechanism allows a generator to either produce content for
the full model or simply provide the end user with instructions on how
to get content in the generated file(s).

There were some supporting framework changes needed to reasonably
enable this feature:

Enable an extension to be marked as non-generative. A non-generative
extension is not used for code generation. These are extensions used
for shape and model browser display and edits to other models. If an
extension does not serialize elements it should always be marked as
NonGenerative=1 in the extension registration. This is done for faster
code generation in the 'generator target' case, which requires a query
of the model itself to determine the files to generate. Given that
shape loading is the majority of the load time in most files, this
significantly improves performance when generating files that are not
already open in the ORM designer.

Replace CustomSerializedXmlNamespaces with new CustomSerializedXmlSchema
attribute. This adds the schema information needed to load the a
schema from an assembly resource without loading the domain model.
This is needed for non-generative loading because we still need the
xml to validate, even though we ignore these elements during load. This
change can be made by running the updated SerializationExtensions
transform, which will produce the correct attribute. The old attribute
is currently deprecated and will be removed in due time.